### PR TITLE
Update mn_combine_strings.py

### DIFF
--- a/nodes/text/mn_combine_strings.py
+++ b/nodes/text/mn_combine_strings.py
@@ -7,7 +7,7 @@ from mn_utils import *
 
 class mn_CombineStringsNode(Node, AnimationNode):
 	bl_idname = "mn_CombineStringsNode"
-	bl_label = "Combine Strings"
+	bl_label = "Combine Texts"
 	
 	def init(self, context):
 		forbidCompiling()


### PR DESCRIPTION
If we decide to call the rest of the nodes "Text", we should avoid using "Strings" for unification.
