### PR TITLE
add object lookup

### DIFF
--- a/nodes/object/mn_object_input.py
+++ b/nodes/object/mn_object_input.py
@@ -18,7 +18,7 @@ class mn_ObjectInputNode(Node, AnimationNode):
 	def draw_buttons(self, context, layout):
 		col = layout.column()
 		row = col.row(align = True)
-		row.prop(self, "objectName", text = "")
+		row.prop_search(self, "objectName",  context.scene, "objects", icon="NONE")         
 		selector = row.operator("mn.assign_active_object_to_node", text = "", icon = "EYEDROPPER")
 		selector.nodeTreeName = self.id_data.name
 		selector.nodeName = self.name


### PR DESCRIPTION
modified the object_input node to allow for object lookup. easier than
selecting the right object and clicking the eyedropper.

This was just a quick test to see if i could get git hub commits and pull requests working. but i do think it is a useful feature.
