### PR TITLE
operations labels for math, vec math nodes Patch 2

### DIFF
--- a/nodes/number/float_math.py
+++ b/nodes/number/float_math.py
@@ -41,9 +41,9 @@ class FloatMathNode(bpy.types.Node, AnimationNode):
     bl_label = "Math"
 
     def operationChanged(self, context):
-        for op in operationItems:
-            if op[0] == self.operation:
-                self.labelOperation = op[2]
+        for item in operationItems:
+            if item[0] == self.operation:
+                self.labelOperation = item[2]
         self.inputs[1].hide = self.operation in singleInputOperations
         executionCodeChanged()
 
@@ -56,8 +56,8 @@ class FloatMathNode(bpy.types.Node, AnimationNode):
     outputInteger = BoolProperty(name = "Output Integer", default = False,
         update = outputIntegerChanged)
 
-    labelOperation = StringProperty(name = "labelOperation", default = "A * B", update = operationChanged)
-    labelOutputType = StringProperty(name = "labelOutputType", default = " (float)", update = outputIntegerChanged)
+    labelOperation = StringProperty(name = "Operation Label", default = "A * B", update = operationChanged)
+    labelOutputType = StringProperty(name = "Output Type Label", default = "float", update = outputIntegerChanged)
 
     def create(self):
         self.inputs.new("an_FloatSocket", "A", "a")
@@ -68,7 +68,7 @@ class FloatMathNode(bpy.types.Node, AnimationNode):
         layout.prop(self, "operation", text = "")
         
     def draw_label(self):
-        return self.labelOperation + self.labelOutputType
+        return self.labelOperation + " (" + self.labelOutputType + ")"
 
     def edit(self):
         targets = self.outputs[0].dataTargets
@@ -81,7 +81,7 @@ class FloatMathNode(bpy.types.Node, AnimationNode):
             self.outputInteger = False
 
     def recreateOutputSocket(self):
-        self.labelOutputType = " (integer)" if self.outputInteger else " (float)" #just to be more clear
+        self.labelOutputType = "integer" if self.outputInteger else "float" #just to be more clear
         
         idName = "an_IntegerSocket" if self.outputInteger else "an_FloatSocket"
         if self.outputs[0].bl_idname == idName: return

--- a/nodes/number/float_math.py
+++ b/nodes/number/float_math.py
@@ -7,31 +7,33 @@ from ... base_types.node import AnimationNode
 
 
 operationItems = [
-    ("ADD", "Add", ""),
-    ("SUBTRACT", "Subtract", ""),
-    ("MULITPLY", "Multiply", ""),
-    ("DIVIDE", "Divide", ""),
-    ("SINE", "Sine", ""),
-    ("COSINE", "Cosine", ""),
-    ("TANGENT", "Tangent", ""),
-    ("ARCSINE", "Arcsine", ""),
-    ("ARCCOSINE", "Arccosine", ""),
-    ("ARCTANGENT", "Arctangent", ""),
-    ("POWER", "Power", ""),
-    ("LOGARITHM", "Logarithm", ""),
-    ("MINIMUM", "Minimum", ""),
-    ("MAXIMUM", "Maximum", ""),
-    ("ROUND", "Round", ""),
-    ("LESSTHAN", "Less Than", ""),
-    ("GREATHERTHAN", "Greather Than", ""),
-    ("MODULO", "Modulo", ""),
-    ("ABSOLUTE", "Absolute", ""),
-    ("FLOOR", "Floor", ""),
-    ("CEILING", "Ceiling", ""),
-    ("SQRT", "Square Root", "")]
+    ("ADD", "Add", "A + B"),
+    ("SUBTRACT", "Subtract", "A - B"),
+    ("MULITPLY", "Multiply", "A * B"),
+    ("DIVIDE", "Divide", "A / B"),
+    ("SINE", "Sine", "sin A"),
+    ("COSINE", "Cosine", "cos A"),
+    ("TANGENT", "Tangent", "tan A"),
+    ("ARCSINE", "Arcsine", "asin A"),
+    ("ARCCOSINE", "Arccosine", "acos A"),
+    ("ARCTANGENT", "Arctangent", "atan A"),
+    ("POWER", "Power", "A ** B"),
+    ("LOGARITHM", "Logarithm", "A log B"),
+    ("MINIMUM", "Minimum", "min A B"),
+    ("MAXIMUM", "Maximum", "max A B"),
+    ("ROUND", "Round", "A round B"),
+    ("LESSTHAN", "Less Than", "A < B"),
+    ("GREATHERTHAN", "Greather Than", "A > B"),
+    ("MODULO", "Modulo", "A % B"),
+    ("ABSOLUTE", "Absolute", "abs A"),
+    ("FLOOR", "Floor", "floor A"),
+    ("CEILING", "Ceiling", "ceil A"),
+    ("SQRT", "Square Root", "sqrt A"),
+    ("INVERT", "Inverted", "- A"),
+    ("RECIPROCAL", "Reciprocal", "1 / A")]
 
 singleInputOperations = ("SINE", "COSINE", "TANGENT", "ARCSINE",
-    "ARCCOSINE", "ARCTANGENT", "ABSOLUTE", "FLOOR", "CEILING", "SQRT")
+    "ARCCOSINE", "ARCTANGENT", "ABSOLUTE", "FLOOR", "CEILING", "SQRT", "INVERT", "RECIPROCAL")
 
 
 class FloatMathNode(bpy.types.Node, AnimationNode):
@@ -39,6 +41,9 @@ class FloatMathNode(bpy.types.Node, AnimationNode):
     bl_label = "Math"
 
     def operationChanged(self, context):
+        for op in operationItems:
+            if op[0] == self.operation:
+                self.labelOperation = op[2]
         self.inputs[1].hide = self.operation in singleInputOperations
         executionCodeChanged()
 
@@ -51,6 +56,9 @@ class FloatMathNode(bpy.types.Node, AnimationNode):
     outputInteger = BoolProperty(name = "Output Integer", default = False,
         update = outputIntegerChanged)
 
+    labelOperation = StringProperty(name = "labelOperation", default = "A * B", update = operationChanged)
+    labelOutputType = StringProperty(name = "labelOutputType", default = " (float)", update = outputIntegerChanged)
+
     def create(self):
         self.inputs.new("an_FloatSocket", "A", "a")
         self.inputs.new("an_FloatSocket", "B", "b").value = 1.0
@@ -58,6 +66,9 @@ class FloatMathNode(bpy.types.Node, AnimationNode):
 
     def draw(self, layout):
         layout.prop(self, "operation", text = "")
+        
+    def draw_label(self):
+        return self.labelOperation + self.labelOutputType
 
     def edit(self):
         targets = self.outputs[0].dataTargets
@@ -70,6 +81,8 @@ class FloatMathNode(bpy.types.Node, AnimationNode):
             self.outputInteger = False
 
     def recreateOutputSocket(self):
+        self.labelOutputType = " (integer)" if self.outputInteger else " (float)" #just to be more clear
+        
         idName = "an_IntegerSocket" if self.outputInteger else "an_FloatSocket"
         if self.outputs[0].bl_idname == idName: return
         self._recreateOutputSocket(idName)
@@ -106,6 +119,8 @@ class FloatMathNode(bpy.types.Node, AnimationNode):
         if op == "FLOOR": yield "result = math.floor(a)"
         if op == "CEILING": yield "result = math.ceil(a)"
         if op == "SQRT": yield "result = math.sqrt(a) if a >= 0 else 0"
+        if op == "INVERT": yield "result = - a"
+        if op == "RECIPROCAL": yield "result = 1 / a if a != 0 else 0"
 
         if self.outputInteger:
             yield "result = int(result)"

--- a/nodes/vector/vector_math.py
+++ b/nodes/vector/vector_math.py
@@ -4,13 +4,15 @@ from ... events import executionCodeChanged
 from ... base_types.node import AnimationNode
 
 operationItems = [
-    ("ADD", "Add", ""),
-    ("SUBTRACT", "Subtract", ""),
-    ("MULTIPLY", "Multiply", "Multiply element by element"),
-    ("DIVIDE", "Divide", "Divide element by element"),
-    ("CROSS", "Cross Product", "Calculate the cross/vector product, yielding a vector that is orthogonal to both input vectors"),
-    ("NORMALIZE", "Normalize", "Scale the vector to a length of 1"),
-    ("SCALE", "Scale", "") ]
+    ("ADD", "Add", "A + B"),
+    ("SUBTRACT", "Subtract", "A - B"),
+    ("MULTIPLY", "Multiply", "A * B       Multiply element by element"),
+    ("DIVIDE", "Divide", "A / B       Divide element by element"),
+    ("CROSS", "Cross Product", "A cross B   Calculate the cross/vector product, yielding a vector that is orthogonal to both input vectors"),
+    ("PROJECT", "Project", "A project B  Projection of A on B, the parallel projection vector"),
+    ("REFLECT", "Reflect", "A reflect B  Reflection of A from mirror B, the reflected vector"),
+    ("NORMALIZE", "Normalize", "A normalize Scale the vector to a length of 1"),
+    ("SCALE", "Scale", "A * scale") ]
 
 operationsWithFloat = ["NORMALIZE", "SCALE"]
 
@@ -19,11 +21,16 @@ class VectorMathNode(bpy.types.Node, AnimationNode):
     bl_label = "Vector Math"
 
     def operationChanged(self, context):
+        for op in operationItems:
+            if op[0] == self.operation:
+                self.labelOperation = op[2][:11]
         self.inputs["B"].hide = self.operation in operationsWithFloat
         self.inputs["Scale"].hide = self.operation not in operationsWithFloat
         executionCodeChanged()
 
     operation = EnumProperty(name = "Operation", items = operationItems, default = "ADD", update = operationChanged)
+
+    labelOperation = StringProperty(name = "labelOperation", default = "A + B", update = operationChanged)
 
     def create(self):
         self.inputs.new("an_VectorSocket", "A", "a")
@@ -35,6 +42,9 @@ class VectorMathNode(bpy.types.Node, AnimationNode):
 
     def draw(self, layout):
         layout.prop(self, "operation", text = "")
+        
+    def draw_label(self):
+        return self.labelOperation
 
     def getExecutionCode(self):
         op = self.operation
@@ -46,6 +56,8 @@ class VectorMathNode(bpy.types.Node, AnimationNode):
                                      "if b[0] != 0: result[0] = a[0] / b[0]",
                                      "if b[1] != 0: result[1] = a[1] / b[1]",
                                      "if b[2] != 0: result[2] = a[2] / b[2]")
+        elif op == "PROJECT": return "result = a.project(b)"
+        elif op == "REFLECT": return "result = a.reflect(b)"
         elif op == "NORMALIZE": return "result = a.normalized() * scale"
         elif op == "SCALE": return "result = a * scale"
 

--- a/nodes/vector/vector_math.py
+++ b/nodes/vector/vector_math.py
@@ -21,16 +21,16 @@ class VectorMathNode(bpy.types.Node, AnimationNode):
     bl_label = "Vector Math"
 
     def operationChanged(self, context):
-        for op in operationItems:
-            if op[0] == self.operation:
-                self.labelOperation = op[2][:11]
+        for item in operationItems:
+            if item[0] == self.operation:
+                self.labelOperation = item[2][:11]
         self.inputs["B"].hide = self.operation in operationsWithFloat
         self.inputs["Scale"].hide = self.operation not in operationsWithFloat
         executionCodeChanged()
 
     operation = EnumProperty(name = "Operation", items = operationItems, default = "ADD", update = operationChanged)
 
-    labelOperation = StringProperty(name = "labelOperation", default = "A + B", update = operationChanged)
+    labelOperation = StringProperty(name = "Operation Label", default = "A + B", update = operationChanged)
 
     def create(self):
         self.inputs.new("an_VectorSocket", "A", "a")


### PR DESCRIPTION
operations labels for math, vec math

math: 
+ node op labels (also show int/float)  
+ added invert,reciproc 
vector math: 
+ node op labels (hehe, the workaround..)  
+ added project(), reflect()