### PR TITLE
obj vis in / out, +filter by name (startswith..)

### DIFF
--- a/nodes/object/object_name_filter.py
+++ b/nodes/object/object_name_filter.py
@@ -1,19 +1,17 @@
 import bpy
+from bpy.props import *
 from ... events import executionCodeChanged
 from ... base_types.node import AnimationNode
+
+filterTypeItems = [("STARTS_WITH", "Starts With", "All Objects with names starting with"),
+                   ("ENDS_WITH", "Ends With", "All Objects with names ending with")]
 
 class ObjectNameFilterNode(bpy.types.Node, AnimationNode):
     bl_idname = "an_ObjectNameFilterNode"
     bl_label = "Object Name Filter"
     
-    def checkedPropertiesChanged(self, context):
-        executionCodeChanged()
-    
-    useCaseSensitive = bpy.props.BoolProperty(default = False, description = "Use Case Sensitive", update = checkedPropertiesChanged)
-    
-    filterType = bpy.props.EnumProperty(items = [("STARTS_WITH", "Starts With", "All Objects with names starting with"),
-                                                 ("ENDS_WITH", "Ends With", "All Objects with names ending with")],
-                                        update = checkedPropertiesChanged, default = "STARTS WITH")
+    useCaseSensitive = BoolProperty(default = False, description = "Use Case Sensitive", update = checkedPropertiesChanged)
+    filterType = EnumProperty(items = filterTypeItems, default = "STARTS_WITH", update = executionCodeChanged)
     
     def create(self):
         self.bl_width_default = 160

--- a/nodes/object/object_name_filter.py
+++ b/nodes/object/object_name_filter.py
@@ -2,19 +2,17 @@ import bpy
 from ... events import executionCodeChanged
 from ... base_types.node import AnimationNode
 
-class an_ObjectNameFilterNode(bpy.types.Node, AnimationNode):
+class ObjectNameFilterNode(bpy.types.Node, AnimationNode):
     bl_idname = "an_ObjectNameFilterNode"
     bl_label = "Object Name Filter"
     
     def checkedPropertiesChanged(self, context):
-        self.updateSocketVisibility()
         executionCodeChanged()
     
-    useAllInScene = bpy.props.BoolProperty(default = False, description = "Use All Objects In Scene instead of socket", update = checkedPropertiesChanged)
     useCaseSensitive = bpy.props.BoolProperty(default = False, description = "Use Case Sensitive", update = checkedPropertiesChanged)
     
-    filterType = bpy.props.EnumProperty(items = [("STARTS WITH", "Starts With", "All Objects with names starting with"),
-                                                 ("ENDS WITH", "Ends With", "All Objects with names ending with")],
+    filterType = bpy.props.EnumProperty(items = [("STARTS_WITH", "Starts With", "All Objects with names starting with"),
+                                                 ("ENDS_WITH", "Ends With", "All Objects with names ending with")],
                                         update = checkedPropertiesChanged, default = "STARTS WITH")
     
     def create(self):
@@ -23,21 +21,13 @@ class an_ObjectNameFilterNode(bpy.types.Node, AnimationNode):
         self.inputs.new("an_ObjectListSocket", "Objects", "objects")
         self.inputs.new("an_StringSocket", "Name", "name")
         self.outputs.new("an_ObjectListSocket", "Objects", "objects")
-        self.outputs.new("an_StringListSocket", "Names", "names").hide = True
-        self.updateSocketVisibility()
-        
+
     def draw(self, layout):
         col = layout.column(align = True)
         row = col.row(align = True)
         row.prop(self, "filterType", text = "Type", expand = True)
-
-        row = col.row(align = True)
-        row.prop(self, "useAllInScene", text = "All Scene Objects", icon = "SCENE_DATA")
         row.prop(self, "useCaseSensitive", text = "", icon = "FONTPREVIEW")
         
-    def updateSocketVisibility(self):
-        self.inputs["Objects"].hide = self.useAllInScene
-
     def getExecutionCode(self):
 
         isLinked = self.getLinkedOutputsDict()
@@ -45,22 +35,20 @@ class an_ObjectNameFilterNode(bpy.types.Node, AnimationNode):
         
         lines = []
         lines.append("obList = []")
-        if self.useAllInScene: lines.append("obList = bpy.context.scene.objects")
-        else: lines.append("if objects is not None: obList = objects")
+        lines.append("if objects is not None: obList = objects")
     
-        lines.append("filteredObjects, filteredNames = [], []")
+        lines.append("filteredObjects = []")
         if self.useCaseSensitive: 
-            if self.filterType == "STARTS WITH": 
+            if self.filterType == "STARTS_WITH": 
                 lines.append("filteredObjects = [ob for ob in obList if ob.name.startswith(str(name))]")
-            if self.filterType == "ENDS WITH": 
+            if self.filterType == "ENDS_WITH": 
                 lines.append("filteredObjects = [ob for ob in obList if ob.name.endswith(str(name))]")
         else: 
-            if self.filterType == "STARTS WITH": 
+            if self.filterType == "STARTS_WITH": 
                 lines.append("filteredObjects = [ob for ob in obList if ob.name.lower().startswith(str.lower(name))]")
-            if self.filterType == "ENDS WITH": 
+            if self.filterType == "ENDS_WITH": 
                 lines.append("filteredObjects = [ob for ob in obList if ob.name.lower().endswith(str.lower(name))]")
         
-        lines.append("filteredNames = [ob.name for ob in filteredObjects]")
-        lines.append("objects, names = filteredObjects, filteredNames")
+        lines.append("objects = filteredObjects")
         
         return lines

--- a/nodes/object/object_name_filter.py
+++ b/nodes/object/object_name_filter.py
@@ -1,0 +1,66 @@
+import bpy
+from ... events import executionCodeChanged
+from ... base_types.node import AnimationNode
+
+class an_ObjectNameFilterNode(bpy.types.Node, AnimationNode):
+    bl_idname = "an_ObjectNameFilterNode"
+    bl_label = "Object Name Filter"
+    
+    def checkedPropertiesChanged(self, context):
+        self.updateSocketVisibility()
+        executionCodeChanged()
+    
+    useAllInScene = bpy.props.BoolProperty(default = False, description = "Use All Objects In Scene instead of socket", update = checkedPropertiesChanged)
+    useCaseSensitive = bpy.props.BoolProperty(default = False, description = "Use Case Sensitive", update = checkedPropertiesChanged)
+    
+    filterType = bpy.props.EnumProperty(items = [("STARTS WITH", "Starts With", "All Objects with names starting with"),
+                                                 ("ENDS WITH", "Ends With", "All Objects with names ending with")],
+                                        update = checkedPropertiesChanged, default = "STARTS WITH")
+    
+    def create(self):
+        self.bl_width_default = 160
+        self.width = 160
+        self.inputs.new("an_ObjectListSocket", "Objects", "objects")
+        self.inputs.new("an_StringSocket", "Name", "name")
+        self.outputs.new("an_ObjectListSocket", "Objects", "objects")
+        self.outputs.new("an_StringListSocket", "Names", "names").hide = True
+        self.updateSocketVisibility()
+        
+    def draw(self, layout):
+        col = layout.column(align = True)
+        row = col.row(align = True)
+        row.prop(self, "filterType", text = "Type", expand = True)
+
+        row = col.row(align = True)
+        row.prop(self, "useAllInScene", text = "All Scene Objects", icon = "SCENE_DATA")
+        row.prop(self, "useCaseSensitive", text = "", icon = "FONTPREVIEW")
+        
+    def updateSocketVisibility(self):
+        self.inputs["Objects"].hide = self.useAllInScene
+
+    def getExecutionCode(self):
+
+        isLinked = self.getLinkedOutputsDict()
+        if not any(isLinked.values()): return ""
+        
+        lines = []
+        lines.append("obList = []")
+        if self.useAllInScene: lines.append("obList = bpy.context.scene.objects")
+        else: lines.append("if objects is not None: obList = objects")
+    
+        lines.append("filteredObjects, filteredNames = [], []")
+        if self.useCaseSensitive: 
+            if self.filterType == "STARTS WITH": 
+                lines.append("filteredObjects = [ob for ob in obList if ob.name.startswith(str(name))]")
+            if self.filterType == "ENDS WITH": 
+                lines.append("filteredObjects = [ob for ob in obList if ob.name.endswith(str(name))]")
+        else: 
+            if self.filterType == "STARTS WITH": 
+                lines.append("filteredObjects = [ob for ob in obList if ob.name.lower().startswith(str.lower(name))]")
+            if self.filterType == "ENDS WITH": 
+                lines.append("filteredObjects = [ob for ob in obList if ob.name.lower().endswith(str.lower(name))]")
+        
+        lines.append("filteredNames = [ob.name for ob in filteredObjects]")
+        lines.append("objects, names = filteredObjects, filteredNames")
+        
+        return lines

--- a/nodes/object/object_visibility_input.py
+++ b/nodes/object/object_visibility_input.py
@@ -1,0 +1,32 @@
+import bpy
+from ... base_types.node import AnimationNode
+
+class an_ObjectVisibilityInput(bpy.types.Node, AnimationNode):
+    bl_idname = "an_ObjectVisibilityInput"
+    bl_label = "Object Visibility Input"
+    outputUseParameterName = "useOutput"
+    
+    def create(self):
+        self.inputs.new("an_ObjectSocket", "Object", "object").defaultDrawType = "PROPERTY_ONLY"
+        self.outputs.new("an_BooleanSocket", "Hide", "hide")
+        self.outputs.new("an_BooleanSocket", "Hide Select", "hideSelect").hide = True
+        self.outputs.new("an_BooleanSocket", "Hide Render", "hideRender")
+        self.outputs.new("an_BooleanSocket", "Show Name", "showName").hide = True
+        self.outputs.new("an_BooleanSocket", "Show Axis", "showAxis").hide = True
+        self.outputs.new("an_BooleanSocket", "Show Xray", "showXray").hide = True
+    
+    def getExecutionCode(self):
+
+        isLinked = self.getLinkedOutputsDict()
+        if not any(isLinked.values()): return ""
+        lines = []
+        lines.append("hide, hideSelect, hideRender, showName, showAxis, showXray = None, None, None, None, None, None")
+        lines.append("if object is not None:")
+        if isLinked["hide"]: lines.append("    hide = object.hide")
+        if isLinked["hideSelect"]: lines.append("    hideSelect = object.hide_select")
+        if isLinked["hideRender"]: lines.append("    hideRender = object.hide_render")
+        if isLinked["showName"]: lines.append("    showName = object.show_name")
+        if isLinked["showAxis"]: lines.append("    showAxis = object.show_axis")
+        if isLinked["showXray"]: lines.append("    showXray = object.show_x_ray")
+        
+        return lines

--- a/nodes/object/object_visibility_input.py
+++ b/nodes/object/object_visibility_input.py
@@ -1,11 +1,10 @@
 import bpy
 from ... base_types.node import AnimationNode
 
-class an_ObjectVisibilityInput(bpy.types.Node, AnimationNode):
-    bl_idname = "an_ObjectVisibilityInput"
+class ObjectVisibilityInputNode(bpy.types.Node, AnimationNode):
+    bl_idname = "an_ObjectVisibilityInputNode"
     bl_label = "Object Visibility Input"
-    outputUseParameterName = "useOutput"
-    
+
     def create(self):
         self.inputs.new("an_ObjectSocket", "Object", "object").defaultDrawType = "PROPERTY_ONLY"
         self.outputs.new("an_BooleanSocket", "Hide", "hide")
@@ -20,7 +19,6 @@ class an_ObjectVisibilityInput(bpy.types.Node, AnimationNode):
         isLinked = self.getLinkedOutputsDict()
         if not any(isLinked.values()): return ""
         lines = []
-        lines.append("hide, hideSelect, hideRender, showName, showAxis, showXray = None, None, None, None, None, None")
         lines.append("if object is not None:")
         if isLinked["hide"]: lines.append("    hide = object.hide")
         if isLinked["hideSelect"]: lines.append("    hideSelect = object.hide_select")
@@ -28,5 +26,6 @@ class an_ObjectVisibilityInput(bpy.types.Node, AnimationNode):
         if isLinked["showName"]: lines.append("    showName = object.show_name")
         if isLinked["showAxis"]: lines.append("    showAxis = object.show_axis")
         if isLinked["showXray"]: lines.append("    showXray = object.show_x_ray")
-        
+        lines.append("else: hide = hideSelect = hideRender = showName = showAxis = showXray = None")
+
         return lines

--- a/nodes/object/object_visibility_output.py
+++ b/nodes/object/object_visibility_output.py
@@ -29,7 +29,7 @@ class ObjectVisibilityOutputNode(bpy.types.Node, AnimationNode):
         self.inputs.new("an_BooleanSocket", "Show Axis", "showAxis")
         self.inputs.new("an_BooleanSocket", "Show Xray", "showXray")
         self.outputs.new("an_ObjectSocket", "Object", "object")
-        for socket in self.inputs: socket.value = False
+        for socket in self.inputs[1:]: socket.value = False
         self.updateSocketVisibility()
         
     def draw(self, layout):
@@ -64,19 +64,19 @@ class ObjectVisibilityOutputNode(bpy.types.Node, AnimationNode):
         
     def getExecutionCode(self):
         lines = []
-        lines.append("if object is not None:")
-        
-        if self.useView: lines.append("    object.hide = hide")
-        if self.useSelect: lines.append("    object.hide_select = hideSelect")
-        if self.useRender: lines.append("    object.hide_render = hideRender")
-        
-        if self.useName: lines.append("    object.show_name = showName")
-        if self.useAxis: lines.append("    object.show_axis = showAxis")
-        if self.useXray: lines.append("    object.show_x_ray = showXray")
-        
         if not any((self.useView, self.useSelect, self.useRender, self.useName, self.useAxis, self.useXray)): 
             lines = []
+        else:
+            lines.append("if object is not None:")
             
+            if self.useView: lines.append("    object.hide = hide")
+            if self.useSelect: lines.append("    object.hide_select = hideSelect")
+            if self.useRender: lines.append("    object.hide_render = hideRender")
+            
+            if self.useName: lines.append("    object.show_name = showName")
+            if self.useAxis: lines.append("    object.show_axis = showAxis")
+            if self.useXray: lines.append("    object.show_x_ray = showXray")
+
         return lines
 
 

--- a/nodes/object/object_visibility_output.py
+++ b/nodes/object/object_visibility_output.py
@@ -1,10 +1,10 @@
 import bpy
-from bpy.props import BoolProperty
+from bpy.props import *
 from ... events import executionCodeChanged
 from ... base_types.node import AnimationNode
 
-class an_ObjectVisibilityOutput(bpy.types.Node, AnimationNode):
-    bl_idname = "an_ObjectVisibilityOutput"
+class ObjectVisibilityOutputNode(bpy.types.Node, AnimationNode):
+    bl_idname = "an_ObjectVisibilityOutputNode"
     bl_label = "Object Visibility Output"
     
     def checkedPropertiesChanged(self, context):
@@ -22,36 +22,37 @@ class an_ObjectVisibilityOutput(bpy.types.Node, AnimationNode):
 
     def create(self):
         self.inputs.new("an_ObjectSocket", "Object", "object").defaultDrawType = "PROPERTY_ONLY"
-        self.inputs.new("an_BooleanSocket", "Hide", "hide").value = False
-        self.inputs.new("an_BooleanSocket", "Hide Select", "hideSelect").value = False
-        self.inputs.new("an_BooleanSocket", "Hide Render", "hideRender").value = False
-        self.inputs.new("an_BooleanSocket", "Show Name", "showName").value = False
-        self.inputs.new("an_BooleanSocket", "Show Axis", "showAxis").value = False
-        self.inputs.new("an_BooleanSocket", "Show Xray", "showXray").value = False
+        self.inputs.new("an_BooleanSocket", "Hide", "hide")
+        self.inputs.new("an_BooleanSocket", "Hide Select", "hideSelect")
+        self.inputs.new("an_BooleanSocket", "Hide Render", "hideRender")
+        self.inputs.new("an_BooleanSocket", "Show Name", "showName")
+        self.inputs.new("an_BooleanSocket", "Show Axis", "showAxis")
+        self.inputs.new("an_BooleanSocket", "Show Xray", "showXray")
         self.outputs.new("an_ObjectSocket", "Object", "object")
+        for socket in self.inputs: socket.value = False
         self.updateSocketVisibility()
         
     def draw(self, layout):
-        rrow = layout.row()
+        row = layout.row()
         
-        col = rrow.column()
-        row = col.row(align = True)
-        row.alignment = 'LEFT'
+        col = row.column()
+        subrow = col.row(align = True)
+        subrow.alignment = 'LEFT'
         #row.label("Visibility")
-        row.prop(self, "useView", text = "", icon = "RESTRICT_VIEW_OFF")
-        row.prop(self, "useSelect", text = "", icon = "RESTRICT_SELECT_OFF")
-        row.prop(self, "useRender", text = "", icon = "RESTRICT_RENDER_OFF")
+        subrow.prop(self, "useView", text = "", icon = "RESTRICT_VIEW_OFF")
+        subrow.prop(self, "useSelect", text = "", icon = "RESTRICT_SELECT_OFF")
+        subrow.prop(self, "useRender", text = "", icon = "RESTRICT_RENDER_OFF")
         
-        col = rrow.column()
-        row = col.row(align = True)
-        row.alignment = 'RIGHT'
+        col = row.column()
+        subrow = col.row(align = True)
+        subrow.alignment = 'RIGHT'
         #row.label("Show")
-        row.prop(self, "useName", text = "", icon = "SORTALPHA")    # SYNTAX_ON / SYNTAX_OFF
-        row.prop(self, "useAxis", text = "", icon = "MANIPUL")    
-        row.prop(self, "useXray", text = "", icon = "ROTACTIVE")    # MOD_DECIM / META_BALL
+        subrow.prop(self, "useName", text = "", icon = "SORTALPHA")    # SYNTAX_ON / SYNTAX_OFF
+        subrow.prop(self, "useAxis", text = "", icon = "MANIPUL")    
+        subrow.prop(self, "useXray", text = "", icon = "ROTACTIVE")    # MOD_DECIM / META_BALL
     
     def drawAdvanced(self, layout):
-        layout.operator("wm.call_menu", text = "Node Info / Help", icon = "INFO").name = "an.show_obj_vis_help"
+        layout.operator("wm.call_menu", text = "Node Info / Help", icon = "INFO").name = "an.show_object_visibility_output_help"
 
     def updateSocketVisibility(self):
         self.inputs["Hide"].hide = not (self.useView)
@@ -76,17 +77,16 @@ class an_ObjectVisibilityOutput(bpy.types.Node, AnimationNode):
         if not any((self.useView, self.useSelect, self.useRender, self.useName, self.useAxis, self.useXray)): 
             lines = []
             
-        #lines.append("object = object")
         return lines
 
 
 class ShowHelp(bpy.types.Menu):
-    bl_idname = "an.show_obj_vis_help"
+    bl_idname = "an.show_object_visibility_output_help"
     bl_label = "Object Visibility Output node | Blender - Animation Nodes"
     bl_icon = "FORCE_TURBULENCE"
     
-    helpText = bpy.props.StringProperty(default = "help here")
-    noteText = bpy.props.StringProperty(default = "note here")
+    helpText = StringProperty(default = "help here")
+    noteText = StringProperty(default = "note here")
     helpLines = []
     noteLines = []
     

--- a/nodes/object/object_visibility_output.py
+++ b/nodes/object/object_visibility_output.py
@@ -1,0 +1,160 @@
+import bpy
+from bpy.props import BoolProperty
+from ... events import executionCodeChanged
+from ... base_types.node import AnimationNode
+
+class an_ObjectVisibilityOutput(bpy.types.Node, AnimationNode):
+    bl_idname = "an_ObjectVisibilityOutput"
+    bl_label = "Object Visibility Output"
+    
+    def checkedPropertiesChanged(self, context):
+        self.updateSocketVisibility()
+        executionCodeChanged()
+    
+    #these are common obj props, the rest are type dependent
+    useView = BoolProperty(name = "Use Hide", default = False, description = "Set Hide (restrict viewport visibility)", update = checkedPropertiesChanged)
+    useSelect = BoolProperty(name = "Use Hide Select", default = False, description = "Set Hide Select (restrict viewport selection)", update = checkedPropertiesChanged)
+    useRender = BoolProperty(name = "Use Hide Render", default = False, description = "Set Hide Render (restrict rendering)", update = checkedPropertiesChanged)
+
+    useName = BoolProperty(name = "Use Name", default = False, description = "Set Show Name (visibility for object name)", update = checkedPropertiesChanged)
+    useAxis = BoolProperty(name = "Use Axis", default = False, description = "Set Show Axis (visibility for object origin and axes)", update = checkedPropertiesChanged)
+    useXray = BoolProperty(name = "Use Xray", default = False, description = "Set Show X-Ray (visibility for the object in front of others)", update = checkedPropertiesChanged)
+
+    def create(self):
+        self.inputs.new("an_ObjectSocket", "Object", "object").defaultDrawType = "PROPERTY_ONLY"
+        self.inputs.new("an_BooleanSocket", "Hide", "hide").value = False
+        self.inputs.new("an_BooleanSocket", "Hide Select", "hideSelect").value = False
+        self.inputs.new("an_BooleanSocket", "Hide Render", "hideRender").value = False
+        self.inputs.new("an_BooleanSocket", "Show Name", "showName").value = False
+        self.inputs.new("an_BooleanSocket", "Show Axis", "showAxis").value = False
+        self.inputs.new("an_BooleanSocket", "Show Xray", "showXray").value = False
+        self.outputs.new("an_ObjectSocket", "Object", "object")
+        self.updateSocketVisibility()
+        
+    def draw(self, layout):
+        rrow = layout.row()
+        
+        col = rrow.column()
+        row = col.row(align = True)
+        row.alignment = 'LEFT'
+        #row.label("Visibility")
+        row.prop(self, "useView", text = "", icon = "RESTRICT_VIEW_OFF")
+        row.prop(self, "useSelect", text = "", icon = "RESTRICT_SELECT_OFF")
+        row.prop(self, "useRender", text = "", icon = "RESTRICT_RENDER_OFF")
+        
+        col = rrow.column()
+        row = col.row(align = True)
+        row.alignment = 'RIGHT'
+        #row.label("Show")
+        row.prop(self, "useName", text = "", icon = "SORTALPHA")    # SYNTAX_ON / SYNTAX_OFF
+        row.prop(self, "useAxis", text = "", icon = "MANIPUL")    
+        row.prop(self, "useXray", text = "", icon = "ROTACTIVE")    # MOD_DECIM / META_BALL
+    
+    def drawAdvanced(self, layout):
+        layout.operator("wm.call_menu", text = "Node Info / Help", icon = "INFO").name = "an.show_obj_vis_help"
+
+    def updateSocketVisibility(self):
+        self.inputs["Hide"].hide = not (self.useView)
+        self.inputs["Hide Select"].hide = not (self.useSelect)
+        self.inputs["Hide Render"].hide = not (self.useRender)
+        self.inputs["Show Name"].hide = not (self.useName)
+        self.inputs["Show Axis"].hide = not (self.useAxis)
+        self.inputs["Show Xray"].hide = not (self.useXray)
+        
+    def getExecutionCode(self):
+        lines = []
+        lines.append("if object is not None:")
+        
+        if self.useView: lines.append("    object.hide = hide")
+        if self.useSelect: lines.append("    object.hide_select = hideSelect")
+        if self.useRender: lines.append("    object.hide_render = hideRender")
+        
+        if self.useName: lines.append("    object.show_name = showName")
+        if self.useAxis: lines.append("    object.show_axis = showAxis")
+        if self.useXray: lines.append("    object.show_x_ray = showXray")
+        
+        if not any((self.useView, self.useSelect, self.useRender, self.useName, self.useAxis, self.useXray)): 
+            lines = []
+            
+        #lines.append("object = object")
+        return lines
+
+
+class ShowHelp(bpy.types.Menu):
+    bl_idname = "an.show_obj_vis_help"
+    bl_label = "Object Visibility Output node | Blender - Animation Nodes"
+    bl_icon = "FORCE_TURBULENCE"
+    
+    helpText = bpy.props.StringProperty(default = "help here")
+    noteText = bpy.props.StringProperty(default = "note here")
+    helpLines = []
+    noteLines = []
+    
+    def draw(self, context):
+        layout = self.layout
+        layout.operator_context = "INVOKE_DEFAULT"
+        layout.label('''Help, comments, notes.''', icon = "INFO")
+        row = layout.row(align = True)
+        
+        col = row.column(align = True)
+        helpLines = self.helpText.split("\n")
+        for li in helpLines:
+            if li:
+                col.label(text=li)
+                
+        col = row.column(align = True)
+        noteLines = self.noteText.split("\n")
+        for li in noteLines:
+            if li:
+                col.label(text=li)
+            
+        layout.label("o.g. 08.2015", icon = "INFO")
+        
+    helpText ='''
+Purpose:
+    This is a convenience node made to ease some ui procedures.
+    Especially useful for objects generated by AN, when many.
+    
+    Allows hiding in the view or render, showing the names etc. ,
+    the commands usually found in Outliner and Object properties panels
+    Having as nodes is especially useful for many instanced objects, 
+    or for hiding source of meshes.
+    
+Usage:
+    Connect after the object you want to change state. Connect in loops
+    for changing many at once. 
+    Check the upper buttons for the parameters you want to affect.
+    The props unchecked will not be affected in the object. This 
+    is important for use in loops, where affecting many objects. 
+    
+    The top row of buttons correspond to the order of sockets:
+    [hide][hide select][hide render]    [show name][show axis][show Xray]
+       hide = hide in viewport
+       hide select = hide from selection
+       hide render = hide from rendering
+       show name = shows name of the object in the viewport
+       show axis = show origin and xyz tripod of the object
+       show Xray = shows the object in front of others, never hidden
+'''
+    noteText ='''
+notes:
+    By default, parameters are Not checked. 
+    Normally it all are Unchecked so that nothing is changed by accident.
+    Also, the default values are False. This being more serious.
+    
+    To change these go into the [an_object_visibility_output.py] file 
+    (normally in animation nodes / nodes / object folder) and
+    by the lines 14 to 20 you'll find the default states of these buttons.
+    Change to True instead of False those that you consider by default
+    
+    You should not change the default values, near the sockets, 
+    as they can lead to unwanted, blind, hiding the moment you plug 
+    an object 
+    
+To explore further:
+    there is also an Object Visibility Input brother node.
+    That reads the state from objects.
+    
+    I think is less used, but it' there for convenience.
+    Normally it is not in menu, so use search (Shift A)
+'''


### PR DESCRIPTION
obj vis input:
should I delete isLinked in vis input? it's kinda too much for this little one, maybe I should let it just do straight the functions ..

ob startswith/ends:
-this is a classic simple filter used in other soft and places
-startswith/endswith are supposed to be way faster than match, so I don't include other search ways

![ob vis in out](https://cloud.githubusercontent.com/assets/11709974/9950140/efe45c66-5dbf-11e5-81cd-729550d1e22e.PNG)
![ob startswith](https://cloud.githubusercontent.com/assets/11709974/9950144/f76819dc-5dbf-11e5-9055-04b440dfaae7.PNG)
