### PR TITLE
added to/from matrix to both eul/quat

### DIFF
--- a/nodes/rotation/convert_quaternion_and_euler.py
+++ b/nodes/rotation/convert_quaternion_and_euler.py
@@ -5,7 +5,11 @@ from ... base_types.node import AnimationNode
 
 conversionTypeItems = [
     ("QUATERNION_TO_EULER", "Quaternion to Euler", "", "NONE", 0),
-    ("EULER_TO_QUATERNION", "Euler To Quaternion", "", "NONE", 1)]
+    ("EULER_TO_QUATERNION", "Euler To Quaternion", "", "NONE", 1),
+    ("QUATERNION_TO_MATRIX", "Quaternion to Matrix", "", "NONE", 2),
+    ("MATRIX_TO_QUATERNION", "Matrix To Quaternion", "", "NONE", 3),
+    ("EULER_TO_MATRIX", "Euler To Matrix", "", "NONE", 4),
+    ("MATRIX_TO_EULER", "Matrix To Euler", "", "NONE", 5)]
 
 class ConvertQuaternionAndEulerNode(bpy.types.Node, AnimationNode):
     bl_idname = "an_ConvertQuaternionAndEulerNode"
@@ -14,7 +18,11 @@ class ConvertQuaternionAndEulerNode(bpy.types.Node, AnimationNode):
     onlySearchTags = True
     searchTags = [
         ("Quaternion to Euler", {"conversionType" : repr("QUATERNION_TO_EULER")}),
-        ("Euler to Quaternion", {"conversionType" : repr("EULER_TO_QUATERNION")}) ]
+        ("Euler to Quaternion", {"conversionType" : repr("EULER_TO_QUATERNION")}),
+        ("Quaternion to Matrix", {"conversionType" : repr("QUATERNION_TO_MATRIX")}),
+        ("Matrix to Quaternion", {"conversionType" : repr("MATRIX_TO_QUATERNION")}),
+        ("Euler To Matrix", {"conversionType" : repr("EULER_TO_MATRIX")}),
+        ("Matrix To Euler", {"conversionType" : repr("MATRIX_TO_EULER")}) ]
 
     def conversionTypeChanged(self, context):
         self.createSockets()
@@ -31,13 +39,24 @@ class ConvertQuaternionAndEulerNode(bpy.types.Node, AnimationNode):
         layout.prop(self, "conversionType", text = "")
 
     def drawLabel(self):
-        return "Euler to Quaternion" if self.conversionType == "EULER_TO_QUATERNION" else "Quaternion to Euler"
+        for item in conversionTypeItems:
+            if self.conversionType == item[0]: return item[1]
 
     def getExecutionCode(self):
         if self.conversionType == "QUATERNION_TO_EULER":
             return "euler = quaternion.to_euler('XYZ')"
         if self.conversionType == "EULER_TO_QUATERNION":
             return "quaternion = euler.to_quaternion()"
+        
+        if self.conversionType == "QUATERNION_TO_MATRIX":
+            return "matrix = quaternion.to_matrix().to_4x4()"
+        if self.conversionType == "MATRIX_TO_QUATERNION":
+            return "quaternion = matrix.to_quaternion()"
+        
+        if self.conversionType == "EULER_TO_MATRIX":
+            return "matrix = euler.to_matrix().to_4x4()"
+        if self.conversionType == "MATRIX_TO_EULER":
+            return "euler = matrix.to_euler('XYZ')"
 
     def getUsedModules(self):
         return ["mathutils"]
@@ -52,4 +71,19 @@ class ConvertQuaternionAndEulerNode(bpy.types.Node, AnimationNode):
         if self.conversionType == "EULER_TO_QUATERNION":
             self.inputs.new("an_EulerSocket", "Euler", "euler")
             self.outputs.new("an_QuaternionSocket", "Quaternion", "quaternion")
+            
+        if self.conversionType == "QUATERNION_TO_MATRIX":
+            self.inputs.new("an_QuaternionSocket", "Quaternion", "quaternion")
+            self.outputs.new("an_MatrixSocket", "Matrix", "matrix")
+        if self.conversionType == "MATRIX_TO_QUATERNION":
+            self.inputs.new("an_MatrixSocket", "Matrix", "matrix")
+            self.outputs.new("an_QuaternionSocket", "Quaternion", "quaternion")
+            
+        if self.conversionType == "EULER_TO_MATRIX":
+            self.inputs.new("an_EulerSocket", "Euler", "euler")
+            self.outputs.new("an_MatrixSocket", "Matrix", "matrix")
+        if self.conversionType == "MATRIX_TO_EULER":
+            self.inputs.new("an_MatrixSocket", "Matrix", "matrix")
+            self.outputs.new("an_EulerSocket", "Euler", "euler")
+            
         self.inputs[0].defaultDrawType = "PROPERTY_ONLY"

--- a/nodes/rotation/convert_rotations.py
+++ b/nodes/rotation/convert_rotations.py
@@ -5,15 +5,15 @@ from ... base_types.node import AnimationNode
 
 conversionTypeItems = [
     ("QUATERNION_TO_EULER", "Quaternion to Euler", "", "NONE", 0),
-    ("EULER_TO_QUATERNION", "Euler To Quaternion", "", "NONE", 1),
+    ("EULER_TO_QUATERNION", "Euler to Quaternion", "", "NONE", 1),
     ("QUATERNION_TO_MATRIX", "Quaternion to Matrix", "", "NONE", 2),
-    ("MATRIX_TO_QUATERNION", "Matrix To Quaternion", "", "NONE", 3),
-    ("EULER_TO_MATRIX", "Euler To Matrix", "", "NONE", 4),
-    ("MATRIX_TO_EULER", "Matrix To Euler", "", "NONE", 5)]
+    ("MATRIX_TO_QUATERNION", "Matrix to Quaternion", "", "NONE", 3),
+    ("EULER_TO_MATRIX", "Euler to Matrix", "", "NONE", 4),
+    ("MATRIX_TO_EULER", "Matrix to Euler", "", "NONE", 5)]
 
-class ConvertQuaternionAndEulerNode(bpy.types.Node, AnimationNode):
-    bl_idname = "an_ConvertQuaternionAndEulerNode"
-    bl_label = "Convert Quaternion and Euler"
+class ConvertRotationsNode(bpy.types.Node, AnimationNode):
+    bl_idname = "an_ConvertRotationsNode"
+    bl_label = "Convert Rotations"
 
     onlySearchTags = True
     searchTags = [
@@ -21,8 +21,8 @@ class ConvertQuaternionAndEulerNode(bpy.types.Node, AnimationNode):
         ("Euler to Quaternion", {"conversionType" : repr("EULER_TO_QUATERNION")}),
         ("Quaternion to Matrix", {"conversionType" : repr("QUATERNION_TO_MATRIX")}),
         ("Matrix to Quaternion", {"conversionType" : repr("MATRIX_TO_QUATERNION")}),
-        ("Euler To Matrix", {"conversionType" : repr("EULER_TO_MATRIX")}),
-        ("Matrix To Euler", {"conversionType" : repr("MATRIX_TO_EULER")}) ]
+        ("Euler to Matrix", {"conversionType" : repr("EULER_TO_MATRIX")}),
+        ("Matrix to Euler", {"conversionType" : repr("MATRIX_TO_EULER")}) ]
 
     def conversionTypeChanged(self, context):
         self.createSockets()


### PR DESCRIPTION
matrix conversion gives clean rotation matrix, ready for transform nodes or matrix combine
(+this will make guided track complete :D )

1
 we need quat / matrix as that opens quat to any transforms
2
 I know euler / matrix is already there, but somehow is never in this concise, rotation only form
- either we have rot matrix separated xyz or in the combine node. i used that a lot for just rotation
- for output we have matrix decompose, but again, I just like having the simple eul to mat/mat to eul when it comes to combining several matrices
(btw, any improvement in the matrix compose?)

3
I also wanted to add quat to vector and angle / vec and angle to quat, but that is weird.
how would you use that in a loop? as separate vec/float or tuple of both?
the axis angle rotation is yet another data type/soc and uses this tuple, while I was more tempted by a separate vec, float in/out as that is easier to deal with in nodes that a weird tuple...