### PR TITLE
adding useWorld as advanced option

### DIFF
--- a/nodes/object/object_bounding_box.py
+++ b/nodes/object/object_bounding_box.py
@@ -1,15 +1,14 @@
 import bpy
 from bpy.props import *
-from ... events import executionCodeChanged
 from mathutils import Vector
+from ... events import propertyChanged
 from ... base_types.node import AnimationNode
 
 class ObjectBoundingBoxNode(bpy.types.Node, AnimationNode):
     bl_idname = "an_ObjectBoundingBoxNode"
     bl_label = "Object Bounding Box"
     
-    useWorldSpace = BoolProperty(name = "Use World Space", default = True,
-        update = executionCodeChanged)
+    useWorldSpace = BoolProperty(name = "Use World Space", default = True, update = propertyChanged)
     
     def create(self):
         self.inputs.new("an_ObjectSocket", "Object", "object").defaultDrawType = "PROPERTY_ONLY"
@@ -21,12 +20,12 @@ class ObjectBoundingBoxNode(bpy.types.Node, AnimationNode):
         layout.prop(self, "useWorldSpace")
     
     def execute(self, object):
-        if object is not None:
-            if self.useWorldSpace:
-                matrix = object.matrix_world
-                vertices = [matrix * Vector(v) for v in object.bound_box]
-            else: vertices = [Vector(v) for v in object.bound_box]
-            edges = [(0, 1), (1, 2), (2, 3), (0, 3), (4, 5), (5, 6), (6, 7), (4, 7), (0, 4), (1, 5), (2, 6), (3, 7)]
-            polygons = [(0, 1, 2, 3), (4, 5, 6, 7), (0, 3, 7, 4), (0, 1, 5, 4), (1, 2, 6, 5), (2, 3, 7, 6)]
-            return vertices, edges, polygons
-        return [], [], []
+        if object is None: return [], [], []
+        
+        if self.useWorldSpace:
+            matrix = object.matrix_world
+            vertices = [matrix * Vector(v) for v in object.bound_box]
+        else: vertices = [Vector(v) for v in object.bound_box]
+        edges = [(0, 1), (1, 2), (2, 3), (0, 3), (4, 5), (5, 6), (6, 7), (4, 7), (0, 4), (1, 5), (2, 6), (3, 7)]
+        polygons = [(0, 1, 2, 3), (4, 5, 6, 7), (0, 3, 7, 4), (0, 1, 5, 4), (1, 2, 6, 5), (2, 3, 7, 6)]
+        return vertices, edges, polygons

--- a/nodes/object/object_bounding_box.py
+++ b/nodes/object/object_bounding_box.py
@@ -1,21 +1,31 @@
 import bpy
+from bpy.props import *
+from ... events import executionCodeChanged
 from mathutils import Vector
 from ... base_types.node import AnimationNode
 
 class ObjectBoundingBoxNode(bpy.types.Node, AnimationNode):
     bl_idname = "an_ObjectBoundingBoxNode"
     bl_label = "Object Bounding Box"
-
+    
+    useWorldSpace = BoolProperty(name = "Use World Space", default = True,
+        update = executionCodeChanged)
+    
     def create(self):
         self.inputs.new("an_ObjectSocket", "Object", "object").defaultDrawType = "PROPERTY_ONLY"
         self.outputs.new("an_VectorListSocket", "Vertices", "vertices")
         self.outputs.new("an_EdgeIndicesListSocket", "Edges", "edges")
         self.outputs.new("an_PolygonIndicesListSocket", "Polygons", "polygons")
-
+        
+    def drawAdvanced(self, layout):
+        layout.prop(self, "useWorldSpace")
+    
     def execute(self, object):
         if object is not None:
-            matrix = object.matrix_world
-            vertices = [matrix * Vector(v) for v in object.bound_box]
+            if self.useWorldSpace:
+                matrix = object.matrix_world
+                vertices = [matrix * Vector(v) for v in object.bound_box]
+            else: vertices = [Vector(v) for v in object.bound_box]
             edges = [(0, 1), (1, 2), (2, 3), (0, 3), (4, 5), (5, 6), (6, 7), (4, 7), (0, 4), (1, 5), (2, 6), (3, 7)]
             polygons = [(0, 1, 2, 3), (4, 5, 6, 7), (0, 3, 7, 4), (0, 1, 5, 4), (1, 2, 6, 5), (2, 3, 7, 6)]
             return vertices, edges, polygons


### PR DESCRIPTION
default still true
this is important as I have used it to compare obj data dimensions with or without transforms

about half on the forum back I was arranging and resizing texts to fit a box or objects to fit each other
I used Bbox to get the original mesh size to compare with the scaled one.
Also useful for min max coords etc (min/max is vert 0-6, opposite corners..in ob space..)