### PR TITLE
make dreaw rectangles a bit transparent

### DIFF
--- a/graphics/interpolation_preview.py
+++ b/graphics/interpolation_preview.py
@@ -11,7 +11,7 @@ class InterpolationPreview:
         self.resolution = resolution
         self.padding = 5
         self.boundary = Rectangle()
-        self.boundary.color = (0.9, 0.9, 0.9, 1)
+        self.boundary.color = (0.9, 0.9, 0.9, 0.6)
         self.boundary.borderThickness = -1
         self.boundary.borderColor = (0.9, 0.76, 0.4, 1.0)
         self.samples = sampleInterpolation(interpolation, amount = resolution)

--- a/graphics/text_box.py
+++ b/graphics/text_box.py
@@ -15,7 +15,7 @@ class TextBox:
         self.lineHeight = self.fontSize / 5 * lineHeightFactor
 
         self.boundary = Rectangle()
-        self.boundary.color = (0.9, 0.9, 0.9, 1)
+        self.boundary.color = (0.9, 0.9, 0.9, 0.6)
         self.boundary.borderThickness = -1
         self.boundary.borderColor = (0.9, 0.76, 0.4, 1.0)
 


### PR DESCRIPTION
these should have a transparency cause
1. you can select and manipulate things underneath without knowing, that can lead to unexpected events
2. you should see if any underneath, after all the nodes are bit transparent too
3. you may even compare graphs or values

goes for both interpolation and drawer (and all that will use rectangle..)