### PR TITLE
Custom Auto Execution Triggers

### DIFF
--- a/base_types/node_tree.py
+++ b/base_types/node_tree.py
@@ -59,7 +59,7 @@ class AnimationNodeTree(bpy.types.NodeTree):
         a = self.autoExecution
 
         # always update the triggers for better visual feedback
-        customTriggerEventRaised = a.customTriggers.update()
+        customTriggerHasBeenActivated = a.customTriggers.update()
 
         if not a.enabled: return False
         if not self.hasMainExecutionUnits: return False
@@ -80,7 +80,7 @@ class AnimationNodeTree(bpy.types.NodeTree):
             if events.intersection({"File", "Addon"}) and \
                 (a.sceneUpdate or a.frameChanged or a.propertyChanged or a.treeChanged): return True
 
-        return customTriggerEventRaised
+        return customTriggerHasBeenActivated
 
     def autoExecute(self):
         self._execute()

--- a/base_types/node_tree.py
+++ b/base_types/node_tree.py
@@ -5,33 +5,11 @@ from .. utils.handlers import eventHandler
 from .. utils.nodes import getAnimationNodeTrees
 from .. events import treeChanged, isRendering, propertyChanged
 from .. nodes.generic.debug_loop import clearDebugLoopTextBlocks
+from . tree_auto_execution_properties import AutoExecutionProperties
 from .. utils.blender_ui import iterActiveScreens, isViewportRendering
 from .. preferences import getBlenderVersion, getAnimationNodesVersion
 from .. tree_info import getNetworksByNodeTree, getSubprogramNetworksByNodeTree
 from .. execution.units import getMainUnitsByNodeTree, setupExecutionUnits, finishExecutionUnits
-
-class AutoExecutionProperties(bpy.types.PropertyGroup):
-
-    enabled = BoolProperty(default = True, name = "Enabled",
-        description = "Enable auto execution for this node tree")
-
-    sceneUpdate = BoolProperty(default = True, name = "Scene Update",
-        description = "Execute many times per second to react on all changes in real time (deactivated during preview rendering)")
-
-    frameChanged = BoolProperty(default = False, name = "Frame Changed",
-        description = "Execute after the frame changed")
-
-    propertyChanged = BoolProperty(default = False, name = "Property Changed",
-        description = "Execute when a attribute in a animation node tree changed")
-
-    treeChanged = BoolProperty(default = False, name = "Tree Changed",
-        description = "Execute when the node tree changes (create/remove links and nodes)")
-
-    minTimeDifference = FloatProperty(name = "Min Time Difference",
-        description = "Auto execute not that often; E.g. only every 0.5 seconds",
-        default = 0.0, min = 0.0, soft_max = 1.0)
-
-    lastExecutionTimestamp = FloatProperty(default = 0.0)
 
 
 class LastTreeExecutionInfo(bpy.types.PropertyGroup):
@@ -97,6 +75,8 @@ class AnimationNodeTree(bpy.types.NodeTree):
             if "Tree" in events and a.treeChanged: return True
             if events.intersection({"File", "Addon"}) and \
                 (a.sceneUpdate or a.frameChanged or a.propertyChanged or a.treeChanged): return True
+
+        if a.customTriggers.update(): return True
 
         return False
 

--- a/base_types/node_tree.py
+++ b/base_types/node_tree.py
@@ -3,9 +3,9 @@ import time
 from bpy.props import *
 from .. utils.handlers import eventHandler
 from .. utils.nodes import getAnimationNodeTrees
+from . tree_auto_execution import AutoExecutionProperties
 from .. events import treeChanged, isRendering, propertyChanged
 from .. nodes.generic.debug_loop import clearDebugLoopTextBlocks
-from . tree_auto_execution_properties import AutoExecutionProperties
 from .. utils.blender_ui import iterActiveScreens, isViewportRendering
 from .. preferences import getBlenderVersion, getAnimationNodesVersion
 from .. tree_info import getNetworksByNodeTree, getSubprogramNetworksByNodeTree
@@ -57,6 +57,10 @@ class AnimationNodeTree(bpy.types.NodeTree):
             return any([screen.is_animation_playing for screen in iterActiveScreens()])
 
         a = self.autoExecution
+
+        # always update the triggers for better visual feedback
+        customTriggerEventRaised = a.customTriggers.update()
+
         if not a.enabled: return False
         if not self.hasMainExecutionUnits: return False
 
@@ -76,9 +80,7 @@ class AnimationNodeTree(bpy.types.NodeTree):
             if events.intersection({"File", "Addon"}) and \
                 (a.sceneUpdate or a.frameChanged or a.propertyChanged or a.treeChanged): return True
 
-        if a.customTriggers.update(): return True
-
-        return False
+        return customTriggerEventRaised
 
     def autoExecute(self):
         self._execute()

--- a/base_types/tree_auto_execution.py
+++ b/base_types/tree_auto_execution.py
@@ -22,7 +22,6 @@ class AutoExecutionTrigger_MonitorProperty(bpy.types.PropertyGroup):
     enabled = BoolProperty(default = True)
     hasError = BoolProperty(default = False)
 
-
     def update(self):
         lastState = self.lastState
         newState = self.getPropertyState()

--- a/base_types/tree_auto_execution_properties.py
+++ b/base_types/tree_auto_execution_properties.py
@@ -1,0 +1,133 @@
+import bpy
+from bpy.props import *
+from .. utils.blender_ui import getDpiFactor
+
+triggerTypeItems = [
+    ("MONITOR_PROPERTY", "Monitor Property", "", "", 0)]
+
+idTypeItems = [
+    ("OBJECT", "Object", "", "OBJECT_DATA", 0),
+    ("SCENE", "Scene", "", "SCENE_DATA", 1)]
+
+class AddAutoExecutionTrigger(bpy.types.Operator):
+    bl_idname = "an.add_auto_execution_trigger"
+    bl_label = "Add Auto Execution Trigger"
+
+    triggerType = EnumProperty(name = "Trigger Type", default = "MONITOR_PROPERTY",
+        items = triggerTypeItems)
+
+    idType = EnumProperty(name = "ID Type", default = "OBJECT",
+        items = idTypeItems)
+
+    @classmethod
+    def poll(cls, context):
+        if context.area.type != "NODE_EDITOR": return False
+        tree = context.space_data.node_tree
+        if tree is None: return False
+        return tree.bl_idname == "an_AnimationNodeTree"
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self, width = 250 * getDpiFactor())
+
+    def draw(self, context):
+        layout = self.layout
+        layout.prop(self, "triggerType")
+        if self.triggerType == "MONITOR_PROPERTY":
+            layout.prop(self, "idType")
+
+    def check(self, context):
+        return True
+
+    def execute(self, context):
+        tree = context.space_data.node_tree
+        trigger = tree.autoExecution.customTriggers.new(self.triggerType)
+        if self.triggerType == "MONITOR_PROPERTY":
+            trigger.idType = self.idType
+        context.area.tag_redraw()
+        return {"FINISHED"}
+
+class AutoExecutionTrigger_MonitorProperty(bpy.types.PropertyGroup):
+
+    idType = EnumProperty(name = "ID Type", default = "OBJECT",
+        items = idTypeItems)
+
+    idObjectName = StringProperty(name = "ID Object Name", default = "")
+    dataPath = StringProperty(name = "Data Path", default = "")
+
+    lastState = StringProperty()
+
+    def update(self):
+        newState = self.getPropertyState()
+        if newState == self.lastState:
+            return False
+        else:
+            self.lastState = newState
+            return True
+
+    def getPropertyState(self):
+        prop = self.getProperty()
+        if prop is None: return ""
+        if hasattr(prop, "__iter__"):
+            return " ".join(str(part) for part in prop)
+        return str(prop)
+
+    def getProperty(self):
+        object = self.getObject()
+        if object is None:
+            return None
+
+        try: return object.path_resolve(self.dataPath)
+        except: return None
+
+    def getObject(self):
+        if self.idType == "OBJECT":
+            return bpy.data.objects.get(self.idObjectName)
+        elif self.idType == "SCENE":
+            return bpy.data.scenes.get(self.idObjectName)
+
+    def draw(self, layout):
+        row = layout.row(align = True)
+        if self.idType == "OBJECT":
+            row.prop_search(self, "idObjectName", bpy.context.scene, "objects", text = "")
+        elif self.idType == "SCENE":
+            row.prop_search(self, "idObjectName", bpy.data, "scenes", text = "")
+        row.prop(self, "dataPath", icon = "RNA", text = "")
+
+
+class CustomAutoExecutionTriggers(bpy.types.PropertyGroup):
+
+    monitorPropertyTriggers = CollectionProperty(type = AutoExecutionTrigger_MonitorProperty)
+
+    def new(self, type):
+        if type == "MONITOR_PROPERTY":
+            return self.monitorPropertyTriggers.add()
+
+    def update(self):
+        triggers = [trigger.update() for trigger in self.monitorPropertyTriggers]
+        return any(triggers)
+
+
+class AutoExecutionProperties(bpy.types.PropertyGroup):
+
+    customTriggers = PointerProperty(type = CustomAutoExecutionTriggers)
+
+    enabled = BoolProperty(default = True, name = "Enabled",
+        description = "Enable auto execution for this node tree")
+
+    sceneUpdate = BoolProperty(default = True, name = "Scene Update",
+        description = "Execute many times per second to react on all changes in real time (deactivated during preview rendering)")
+
+    frameChanged = BoolProperty(default = False, name = "Frame Changed",
+        description = "Execute after the frame changed")
+
+    propertyChanged = BoolProperty(default = False, name = "Property Changed",
+        description = "Execute when a attribute in a animation node tree changed")
+
+    treeChanged = BoolProperty(default = False, name = "Tree Changed",
+        description = "Execute when the node tree changes (create/remove links and nodes)")
+
+    minTimeDifference = FloatProperty(name = "Min Time Difference",
+        description = "Auto execute not that often; E.g. only every 0.5 seconds",
+        default = 0.0, min = 0.0, soft_max = 1.0)
+
+    lastExecutionTimestamp = FloatProperty(default = 0.0)

--- a/base_types/tree_auto_execution_properties.py
+++ b/base_types/tree_auto_execution_properties.py
@@ -1,6 +1,7 @@
 import bpy
 from bpy.props import *
 from .. utils.blender_ui import getDpiFactor
+from .. utils.id_reference import tryToFindObjectReference
 
 triggerTypeItems = [
     ("MONITOR_PROPERTY", "Monitor Property", "", "", 0)]
@@ -8,43 +9,6 @@ triggerTypeItems = [
 idTypeItems = [
     ("OBJECT", "Object", "", "OBJECT_DATA", 0),
     ("SCENE", "Scene", "", "SCENE_DATA", 1)]
-
-class AddAutoExecutionTrigger(bpy.types.Operator):
-    bl_idname = "an.add_auto_execution_trigger"
-    bl_label = "Add Auto Execution Trigger"
-
-    triggerType = EnumProperty(name = "Trigger Type", default = "MONITOR_PROPERTY",
-        items = triggerTypeItems)
-
-    idType = EnumProperty(name = "ID Type", default = "OBJECT",
-        items = idTypeItems)
-
-    @classmethod
-    def poll(cls, context):
-        if context.area.type != "NODE_EDITOR": return False
-        tree = context.space_data.node_tree
-        if tree is None: return False
-        return tree.bl_idname == "an_AnimationNodeTree"
-
-    def invoke(self, context, event):
-        return context.window_manager.invoke_props_dialog(self, width = 250 * getDpiFactor())
-
-    def draw(self, context):
-        layout = self.layout
-        layout.prop(self, "triggerType")
-        if self.triggerType == "MONITOR_PROPERTY":
-            layout.prop(self, "idType")
-
-    def check(self, context):
-        return True
-
-    def execute(self, context):
-        tree = context.space_data.node_tree
-        trigger = tree.autoExecution.customTriggers.new(self.triggerType)
-        if self.triggerType == "MONITOR_PROPERTY":
-            trigger.idType = self.idType
-        context.area.tag_redraw()
-        return {"FINISHED"}
 
 class AutoExecutionTrigger_MonitorProperty(bpy.types.PropertyGroup):
 
@@ -55,6 +19,7 @@ class AutoExecutionTrigger_MonitorProperty(bpy.types.PropertyGroup):
     dataPath = StringProperty(name = "Data Path", default = "")
 
     lastState = StringProperty()
+    enabled = BoolProperty(default = True)
 
     def update(self):
         newState = self.getPropertyState()
@@ -62,7 +27,7 @@ class AutoExecutionTrigger_MonitorProperty(bpy.types.PropertyGroup):
             return False
         else:
             self.lastState = newState
-            return True
+            return self.enabled
 
     def getPropertyState(self):
         prop = self.getProperty()
@@ -85,13 +50,26 @@ class AutoExecutionTrigger_MonitorProperty(bpy.types.PropertyGroup):
         elif self.idType == "SCENE":
             return bpy.data.scenes.get(self.idObjectName)
 
-    def draw(self, layout):
-        row = layout.row(align = True)
+    def updateNameProperty(self):
         if self.idType == "OBJECT":
-            row.prop_search(self, "idObjectName", bpy.context.scene, "objects", text = "")
+            object = tryToFindObjectReference(self.idObjectName)
+            self.idObjectName = getattr(object, "name", "")
+
+    def draw(self, layout, index):
+        row = layout.row(align = False)
+        icon = "LAYER_ACTIVE" if self.enabled else "LAYER_USED"
+
+        subrow = row.row(align = True)
+        subrow.active = self.enabled
+        subrow.prop(self, "enabled", icon = icon, text = "")
+        if self.idType == "OBJECT":
+            subrow.prop_search(self, "idObjectName", bpy.context.scene, "objects", text = "")
         elif self.idType == "SCENE":
-            row.prop_search(self, "idObjectName", bpy.data, "scenes", text = "")
-        row.prop(self, "dataPath", icon = "RNA", text = "")
+            subrow.prop_search(self, "idObjectName", bpy.data, "scenes", text = "")
+        subrow.prop(self, "dataPath", icon = "RNA", text = "")
+        props = subrow.operator("an.remove_auto_execution_trigger", icon = "X", text = "")
+        props.triggerType = "MONITOR_PROPERTY"
+        props.index = index
 
 
 class CustomAutoExecutionTriggers(bpy.types.PropertyGroup):
@@ -105,6 +83,10 @@ class CustomAutoExecutionTriggers(bpy.types.PropertyGroup):
     def update(self):
         triggers = [trigger.update() for trigger in self.monitorPropertyTriggers]
         return any(triggers)
+
+    def updateProperties(self):
+        for trigger in self.monitorPropertyTriggers:
+            trigger.updateNameProperty()
 
 
 class AutoExecutionProperties(bpy.types.PropertyGroup):
@@ -131,3 +113,60 @@ class AutoExecutionProperties(bpy.types.PropertyGroup):
         default = 0.0, min = 0.0, soft_max = 1.0)
 
     lastExecutionTimestamp = FloatProperty(default = 0.0)
+
+
+class AddAutoExecutionTrigger(bpy.types.Operator):
+    bl_idname = "an.add_auto_execution_trigger"
+    bl_label = "Add Auto Execution Trigger"
+    bl_options = {"UNDO"}
+
+    triggerType = EnumProperty(name = "Trigger Type", default = "MONITOR_PROPERTY",
+        items = triggerTypeItems)
+
+    idType = EnumProperty(name = "ID Type", default = "OBJECT",
+        items = idTypeItems)
+
+    @classmethod
+    def poll(cls, context):
+        return context.isAnimationNodeTreeActive()
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self, width = 250 * getDpiFactor())
+
+    def draw(self, context):
+        layout = self.layout
+        layout.prop(self, "triggerType")
+        if self.triggerType == "MONITOR_PROPERTY":
+            layout.prop(self, "idType")
+
+    def check(self, context):
+        return True
+
+    def execute(self, context):
+        tree = context.space_data.node_tree
+        trigger = tree.autoExecution.customTriggers.new(self.triggerType)
+        if self.triggerType == "MONITOR_PROPERTY":
+            trigger.idType = self.idType
+        context.area.tag_redraw()
+        return {"FINISHED"}
+
+
+class RemoveAutoExecutionTrigger(bpy.types.Operator):
+    bl_idname = "an.remove_auto_execution_trigger"
+    bl_label = "Remove Auto Execution Trigger"
+    bl_options = {"UNDO"}
+
+    triggerType = EnumProperty(items = triggerTypeItems)
+    index = IntProperty()
+
+    @classmethod
+    def poll(cls, context):
+        return context.isAnimationNodeTreeActive()
+
+    def execute(self, context):
+        tree = context.space_data.node_tree
+        customTriggers = tree.autoExecution.customTriggers
+
+        if self.triggerType == "MONITOR_PROPERTY":
+            customTriggers.monitorPropertyTriggers.remove(self.index)
+        return {"FINISHED"}

--- a/base_types/tree_auto_execution_properties.py
+++ b/base_types/tree_auto_execution_properties.py
@@ -76,9 +76,12 @@ class CustomAutoExecutionTriggers(bpy.types.PropertyGroup):
 
     monitorPropertyTriggers = CollectionProperty(type = AutoExecutionTrigger_MonitorProperty)
 
-    def new(self, type):
+    def new(self, type, **kwargs):
         if type == "MONITOR_PROPERTY":
-            return self.monitorPropertyTriggers.add()
+            item = self.monitorPropertyTriggers.add()
+        for key, value in kwargs.items():
+            setattr(item, key, value)
+        return item
 
     def update(self):
         triggers = [trigger.update() for trigger in self.monitorPropertyTriggers]

--- a/event_handler.py
+++ b/event_handler.py
@@ -17,7 +17,7 @@ def update(events):
     if events.intersection({"File", "Addon", "Tree"}) or didNameChange():
         updateEverything()
 
-    updateSocketProperties()
+    updateProperties()
 
     if problems.canAutoExecute():
         nodeTrees = list(iterAutoExecutionNodeTrees(events))
@@ -53,6 +53,9 @@ def getNamesHash():
         (node.name for node in iterAnimationNodes())))
     return names
 
-def updateSocketProperties():
+def updateProperties():
     for socket in iterSocketsThatNeedUpdate():
         socket.updateProperty()
+
+    for tree in getAnimationNodeTrees():
+        tree.autoExecution.customTriggers.updateProperties()

--- a/extend_bpy_types.py
+++ b/extend_bpy_types.py
@@ -1,0 +1,14 @@
+import bpy
+
+def register():
+    bpy.types.Context.isAnimationNodeTreeActive = isAnimationNodeTreeActive
+
+def unregister():
+    del bpy.types.Context.isAnimationNodeTreeActive
+
+def isAnimationNodeTreeActive(context):
+    if context.area.type == "NODE_EDITOR":
+        tree = context.space_data.node_tree
+        if tree is not None:
+            return tree.bl_idname == "an_AnimationNodeTree"
+    return False

--- a/nodes/generic/expression.py
+++ b/nodes/generic/expression.py
@@ -12,6 +12,7 @@ class ExpressionNode(bpy.types.Node, AnimationNode):
     bl_idname = "an_ExpressionNode"
     bl_label = "Expression"
     bl_width_default = 200
+    dynamicLabelType = "HIDDEN_ONLY"
 
     def settingChanged(self, context = None):
         self.executionError = ""
@@ -56,6 +57,9 @@ class ExpressionNode(bpy.types.Node, AnimationNode):
         layout.prop(self, "debugMode")
         layout.prop(self, "outputIsList")
         layout.prop(self, "moduleNames")
+
+    def drawLabel(self):
+        return self.expression
 
     def drawControlSocket(self, layout, socket):
         left, right = splitAlignment(layout)

--- a/nodes/object/object_attribute_input.py
+++ b/nodes/object/object_attribute_input.py
@@ -23,6 +23,9 @@ class ObjectAttributeInputNode(bpy.types.Node, AnimationNode):
         if self.errorMessage != "":
             layout.label(self.errorMessage, icon = "ERROR")
 
+    def drawAdvanced(self, layout):
+        self.invokeFunction(layout, "createAutoExecutionTrigger", text = "Create Execution Trigger")
+
     def getExecutionCode(self):
         code = self.evaluationExpression
 
@@ -43,3 +46,9 @@ class ObjectAttributeInputNode(bpy.types.Node, AnimationNode):
     def evaluationExpression(self):
         if self.attribute.startswith("["): return "value = object" + self.attribute
         else: return "value = object." + self.attribute
+
+    def createAutoExecutionTrigger(self):
+        item = self.nodeTree.autoExecution.customTriggers.new("MONITOR_PROPERTY")
+        item.idType = "OBJECT"
+        item.dataPath = self.attribute
+        item.idObjectName = self.inputs["Object"].objectName

--- a/nodes/object/object_transforms_input.py
+++ b/nodes/object/object_transforms_input.py
@@ -50,6 +50,7 @@ class ObjectTransformsInputNode(bpy.types.Node, AnimationNode):
         col = layout.column()
         col.active = not self.useCurrentTransforms
         col.prop(self, "frameType")
+        self.invokeFunction(layout, "createAutoExecutionTrigger", text = "Create Execution Trigger")
 
     def getExecutionCode(self):
         isLinked = self.getLinkedOutputsDict()
@@ -77,3 +78,18 @@ class ObjectTransformsInputNode(bpy.types.Node, AnimationNode):
 
     def getUsedModules(self):
         return ["mathutils"]
+
+    def createAutoExecutionTrigger(self):
+        isLinked = self.getLinkedOutputsDict()
+        customTriggers = self.nodeTree.autoExecution.customTriggers
+
+        objectName = self.inputs["Object"].objectName
+
+        if isLinked["location"]:
+            customTriggers.new("MONITOR_PROPERTY", idType = "OBJECT", dataPath = "location", idObjectName = objectName)
+        if isLinked["rotation"]:
+            customTriggers.new("MONITOR_PROPERTY", idType = "OBJECT", dataPath = "rotation_euler", idObjectName = objectName)
+        if isLinked["scale"]:
+            customTriggers.new("MONITOR_PROPERTY", idType = "OBJECT", dataPath = "scale", idObjectName = objectName)
+        if isLinked["quaternion"]:
+            customTriggers.new("MONITOR_PROPERTY", idType = "OBJECT", dataPath = "rotation_quaternion", idObjectName = objectName)

--- a/register_files.py
+++ b/register_files.py
@@ -4,8 +4,9 @@ from . import utils
 from . import keymap
 from . import id_keys
 from . import draw_handler
-from . ui import node_colors
 from . ui import node_panel
+from . ui import node_colors
+from . import extend_bpy_types
 from . operators import dynamic_operators
 from . base_types import node as node_base
 from . nodes.sound import bake as sound_bake
@@ -20,6 +21,7 @@ def registerFiles():
     node_colors.register()
     draw_handler.register()
     utils.operators.register()
+    extend_bpy_types.register()
     dynamic_operators.register()
     node_panel.register()
     utils.handlers.registerHandlers()
@@ -35,6 +37,7 @@ def unregisterFiles():
     node_colors.unregister()
     draw_handler.unregister()
     utils.operators.unregister()
+    extend_bpy_types.unregister()
     dynamic_operators.unregister()
     node_panel.unregister()
     utils.handlers.unregisterHandlers()

--- a/sockets/object.py
+++ b/sockets/object.py
@@ -21,7 +21,7 @@ class ObjectSocket(bpy.types.NodeSocket, AnimationNodeSocket):
 
         scene = self.nodeTree.scene
         if scene is None: scene = bpy.context.scene
-        row.prop_search(self, "objectName",  scene, "objects", icon = "NONE", text = text)
+        row.prop_search(self, "objectName", scene, "objects", icon = "NONE", text = text)
 
         if self.objectCreationType != "":
             self.invokeFunction(row, "createObject", icon = "PLUS")

--- a/ui/auto_execution_panel.py
+++ b/ui/auto_execution_panel.py
@@ -44,6 +44,12 @@ class AutoExecutionPanel(bpy.types.Panel):
 
         layout.prop(autoExecution, "minTimeDifference", slider = True)
 
+        col = layout.column()
+        col.operator("an.add_auto_execution_trigger")
+        customTriggers = autoExecution.customTriggers
+        for monitorPropTrigger in customTriggers.monitorPropertyTriggers:
+            monitorPropTrigger.draw(col)
+
     @classmethod
     def getTree(cls):
         return bpy.context.space_data.edit_tree

--- a/ui/auto_execution_panel.py
+++ b/ui/auto_execution_panel.py
@@ -23,12 +23,17 @@ class AutoExecutionPanel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
 
+        tree = context.space_data.edit_tree
+        autoExecution = tree.autoExecution
+
+        isRendering = isViewportRendering()
+
         if not canExecute():
             layout.label("Look in the 'Problems' panel", icon = "INFO")
 
-        tree = context.space_data.edit_tree
-        autoExecution = tree.autoExecution
-        isRendering = isViewportRendering()
+        if not tree.hasMainExecutionUnits:
+            layout.label("There are no nodes to execute in this tree", icon = "INFO")
+
         layout.active = autoExecution.enabled
 
         col = layout.column()

--- a/ui/auto_execution_panel.py
+++ b/ui/auto_execution_panel.py
@@ -45,6 +45,7 @@ class AutoExecutionPanel(bpy.types.Panel):
         layout.prop(autoExecution, "minTimeDifference", slider = True)
 
         col = layout.column()
+        col.operator("an.add_auto_execution_trigger", text = "New Trigger", icon = "ZOOMIN")
         customTriggers = autoExecution.customTriggers
 
         subcol = col.column(align = True)

--- a/ui/auto_execution_panel.py
+++ b/ui/auto_execution_panel.py
@@ -31,9 +31,6 @@ class AutoExecutionPanel(bpy.types.Panel):
         if not canExecute():
             layout.label("Look in the 'Problems' panel", icon = "INFO")
 
-        if not tree.hasMainExecutionUnits:
-            layout.label("There are no nodes to execute in this tree", icon = "INFO")
-
         layout.active = autoExecution.enabled
 
         col = layout.column()

--- a/ui/auto_execution_panel.py
+++ b/ui/auto_execution_panel.py
@@ -45,7 +45,6 @@ class AutoExecutionPanel(bpy.types.Panel):
         layout.prop(autoExecution, "minTimeDifference", slider = True)
 
         col = layout.column()
-        col.operator("an.add_auto_execution_trigger")
         customTriggers = autoExecution.customTriggers
 
         subcol = col.column(align = True)

--- a/ui/auto_execution_panel.py
+++ b/ui/auto_execution_panel.py
@@ -47,8 +47,10 @@ class AutoExecutionPanel(bpy.types.Panel):
         col = layout.column()
         col.operator("an.add_auto_execution_trigger")
         customTriggers = autoExecution.customTriggers
-        for monitorPropTrigger in customTriggers.monitorPropertyTriggers:
-            monitorPropTrigger.draw(col)
+
+        subcol = col.column(align = True)
+        for i, monitorPropertyTrigger in enumerate(customTriggers.monitorPropertyTriggers):
+            monitorPropertyTrigger.draw(subcol, i)
 
     @classmethod
     def getTree(cls):


### PR DESCRIPTION
This feature will become very handy when you control something with object locations or other properties. Until now you had to have *Always* activated for realtime feedback when changing the controler objects. With this new feature you can make it so that the tree is only executed when a specific object moves (this is only one specific example, you can do much more)

There are two ways to create custom triggers:

1. In the *Auto Execution* panel is a new *New Trigger* button. When you click on it you can choose a trigger type. Currently there is only "Monitor Property" but I plan to have at least one more entry there. Additionally you have to decide which type the object has you want to monitor. Currently there is only "Object" and "Scene". This can be extended as well when needed. Afterwards you can change the monitored data path in the Auto Execution panel.
2. Most of the time you use the *Object Transforms Input* or *Object Attribute Input* node to get data from objects. Both have a new button in the advanced panel that allows you to create the exact trigger you need very easily. We can also implement this button for other nodes when needed.

Individual Triggers can be disabled with the button on the right (similiar to how we disabled and enable sockets in some nodes).

It's a good trick to use matrix_world as datapath when you want to monitor the location, rotation and scale of an object.

![auto execution panel](https://cloud.githubusercontent.com/assets/5881326/14512270/ce2d3fbc-01dd-11e6-8f40-982c87f6118f.PNG)

![create execution trigger](https://cloud.githubusercontent.com/assets/5881326/14512272/d285d862-01dd-11e6-8208-e5f6c2cf71f0.PNG)

![more triggers](https://cloud.githubusercontent.com/assets/5881326/14512274/d5358a3a-01dd-11e6-9c0f-f18c77cf4fd6.PNG)


