### PR TITLE
Add option to not copy addon files to Blender's addon directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ def main():
         compileCythonFiles()
         if "-export" in initialArgs:
             export()
+        if "-nocopy" in initialArgs:
+            return
         if os.path.isdir(config["addonsDirectory"]):
             copyToBlender()
         else:


### PR DESCRIPTION
For me personally it's a bit annoying that the files will be copied over when building. So I thought it might be nice to add on option to disable this.