### PR TITLE
Vector output, center along options and order change for grid option in distribute node.

### DIFF
--- a/animation_nodes/nodes/matrix/compose_matrix.py
+++ b/animation_nodes/nodes/matrix/compose_matrix.py
@@ -119,6 +119,7 @@ class ComposeMatrixNode(bpy.types.Node, AnimationNode):
             yield "matrix = AN.utils.math.composeMatrix(translation, rotation, scale)"
 
     def calculateMatrices(self, translation, rotation, scale):
+        if not any([self.useTranslation, self.useRotation, self.useScale]): return Matrix4x4List()
         translations = VirtualVector3DList.create(translation, (0, 0, 0))
         rotations = VirtualEulerList.create(rotation, (0, 0, 0))
         scales = VirtualVector3DList.create(scale, (1, 1, 1))

--- a/animation_nodes/nodes/matrix/distribute_matrices.pyx
+++ b/animation_nodes/nodes/matrix/distribute_matrices.pyx
@@ -42,6 +42,13 @@ class DistributeMatricesNode(bpy.types.Node, AnimationNode):
     meshMode = EnumProperty(name = "Mesh Mode", default = "VERTICES",
         items = meshModeItems, update = AnimationNode.refresh)
 
+    centerAlongX = BoolProperty(name = "Center Along X", default = True,
+        description = "Center the grid along the x axis.", update = AnimationNode.refresh)
+    centerAlongY = BoolProperty(name = "Center Along Y", default = True,
+        description = "Center the grid along the y axis.", update = AnimationNode.refresh)
+    centerAlongZ = BoolProperty(name = "Center Along Z", default = False,
+        description = "Center the grid along the z axis.", update = AnimationNode.refresh)
+
     exactCircleSegment = BoolProperty(name = "Exact Circle Segment", default = False)
 
     def create(self):
@@ -88,6 +95,11 @@ class DistributeMatricesNode(bpy.types.Node, AnimationNode):
             col.prop(self, "distanceMode", text = "")
         if self.mode == "MESH":
             col.prop(self, "meshMode", text = "")
+        if self.mode == "GRID":
+            row = col.row(align = True)
+            row.prop(self, "centerAlongX", text = "X", toggle = True)
+            row.prop(self, "centerAlongY", text = "Y", toggle = True)
+            row.prop(self, "centerAlongZ", text = "Z", toggle = True)
 
     def drawAdvanced(self, layout):
         if self.mode == "CIRCLE":
@@ -139,8 +151,9 @@ class DistributeMatricesNode(bpy.types.Node, AnimationNode):
             yDis = size2 / max(yDiv - 1, 1)
             zDis = size3 / max(zDiv - 1, 1)
 
-        xOffset = xDis * (xDiv - 1) / 2
-        yOffset = yDis * (yDiv - 1) / 2
+        xOffset = xDis * (xDiv - 1) / 2 * self.centerAlongX
+        yOffset = yDis * (yDiv - 1) / 2 * self.centerAlongY
+        zOffset = zDis * (zDiv - 1) / 2 * self.centerAlongZ
 
         for x in range(xDiv):
             for y in range(yDiv):
@@ -148,7 +161,7 @@ class DistributeMatricesNode(bpy.types.Node, AnimationNode):
                     index = z * xDiv * yDiv + y * xDiv + x
                     vector.x = <float>(x * xDis - xOffset)
                     vector.y = <float>(y * yDis - yOffset)
-                    vector.z = <float>(z * zDis)
+                    vector.z = <float>(z * zDis - zOffset)
                     setTranslationMatrix(matrices.data + index, &vector)
 
         return matrices

--- a/animation_nodes/nodes/matrix/distribute_matrices.pyx
+++ b/animation_nodes/nodes/matrix/distribute_matrices.pyx
@@ -145,7 +145,7 @@ class DistributeMatricesNode(bpy.types.Node, AnimationNode):
         for x in range(xDiv):
             for y in range(yDiv):
                 for z in range(zDiv):
-                    index = x * yDiv * zDiv + y * zDiv + z
+                    index = z * xDiv * yDiv + y * xDiv + x
                     vector.x = <float>(x * xDis - xOffset)
                     vector.y = <float>(y * yDis - yOffset)
                     vector.z = <float>(z * zDis)


### PR DESCRIPTION
- Added vector list output for distribute matrices node.
- Added center along axis options for distribute matrices node grid option.
- Changed the order of points/matrices for the grid option in the distribute matrices node such that it grows on x, then y, then z (Conventional cartesian indexing).
- Fixed bug in Compose Matrix node where if all options were disabled and the output was connected to a matrix list, a fatal error occur.
