### PR TITLE
fix for #928 – clone data on node duplication

### DIFF
--- a/animation_nodes/base_types/nodes/base_node.py
+++ b/animation_nodes/base_types/nodes/base_node.py
@@ -166,7 +166,7 @@ class AnimationNode:
 
     def copy(self, sourceNode):
         self.identifier = createIdentifier()
-        infoByNode[self.identifier] = infoByNode[sourceNode.identifier]
+        infoByNode[self.identifier] = infoByNode[sourceNode.identifier].clone()
         self.duplicate(sourceNode)
 
     def free(self):
@@ -679,6 +679,16 @@ class NonPersistentNodeData:
         self.codeEffects = []
         self.errorMessage = None
         self.showErrorMessage = True
+
+    def clone(self):
+        newData = NonPersistentNodeData()
+        for (k, v) in self.inputs.items():
+            newData.inputs[k] = v
+
+        for (k, v) in self.outputs.items():
+            newData.outputs[k] = v
+
+        return newData
 
 infoByNode = defaultdict(NonPersistentNodeData)
 


### PR DESCRIPTION
Hi,

I've fixed (I think) a data-sharing problem on node duplication, noted in issue https://github.com/JacquesLucke/animation_nodes/issues/928

I'm not sure if copying inputs/outputs in my clone() method is strictly necessary, as links aren't maintained, but it seemed the smallest change. Let me know if I need to rethink any of this!