### PR TITLE
Refactor and improve Execution Triggers.

### DIFF
--- a/animation_nodes/base_types/tree_auto_execution.py
+++ b/animation_nodes/base_types/tree_auto_execution.py
@@ -55,8 +55,9 @@ class AutoExecutionTrigger_MonitorProperty(bpy.types.PropertyGroup):
 
         try:
             properties = []
+            paths = self.getDataPaths()
             for idBlock in idBlocks:
-                properties.extend(idBlock.path_resolve(p) for p in self.getDataPaths())
+                properties.extend(idBlock.path_resolve(p) for p in paths)
             return properties
         except:
             self.hasError = True

--- a/animation_nodes/base_types/tree_auto_execution.py
+++ b/animation_nodes/base_types/tree_auto_execution.py
@@ -50,17 +50,20 @@ class AutoExecutionTrigger_MonitorProperty(bpy.types.PropertyGroup):
 
     def getProperties(self):
         self.hasError = False
-        IDBlocks = self.getIDBlocks()
-        if len(IDBlocks) == 0 or self.dataPaths.strip() is "": return []
+        idBlocks = self.getIDBlocks()
+        if len(idBlocks) == 0 or self.dataPaths.strip() is "": return []
 
         try:
             properties = []
-            for IDBlock in IDBlocks:
-                properties.extend(IDBlock.path_resolve(p.strip()) for p in self.dataPaths.split(","))
+            for idBlock in idBlocks:
+                properties.extend(idBlock.path_resolve(p) for p in self.getDataPaths())
             return properties
         except:
             self.hasError = True
             return []
+
+    def getDataPaths(self):
+        return [p.strip() for p in self.dataPaths.split(",")]
 
     def getIDBlocks(self):
         if self.idType == "OBJECT":

--- a/animation_nodes/base_types/tree_auto_execution.py
+++ b/animation_nodes/base_types/tree_auto_execution.py
@@ -50,19 +50,19 @@ class AutoExecutionTrigger_MonitorProperty(bpy.types.PropertyGroup):
 
     def getProperties(self):
         self.hasError = False
-        objects = self.getObjects()
-        if len(objects) == 0 or self.dataPaths.strip() is "": return []
+        IDBlocks = self.getIDBlocks()
+        if len(IDBlocks) == 0 or self.dataPaths.strip() is "": return []
 
         try:
             properties = []
-            for obj in objects:
-                properties.extend(obj.path_resolve(p.strip()) for p in self.dataPaths.split(","))
+            for IDBlock in IDBlocks:
+                properties.extend(IDBlock.path_resolve(p.strip()) for p in self.dataPaths.split(","))
             return properties
         except:
             self.hasError = True
             return []
 
-    def getObjects(self):
+    def getIDBlocks(self):
         if self.idType == "OBJECT":
             if self.object is None: return []
             return [self.object]

--- a/animation_nodes/base_types/tree_auto_execution.py
+++ b/animation_nodes/base_types/tree_auto_execution.py
@@ -47,30 +47,28 @@ class AutoExecutionTrigger_MonitorProperty(bpy.types.PropertyGroup):
 
     def getProperties(self):
         self.hasError = False
-        object = self.getObject()
-        if object is None or self.dataPaths.strip() is "":
-            return []
+        objects = self.getObjects()
+        if len(objects) == 0 or self.dataPaths.strip() is "": return []
 
         try:
-            paths = self.dataPaths.split(",")
-            if self.idType == "COLLECTION":
-                properties = []
-                for obj in object.all_objects:
-                    properties.extend(obj.path_resolve(p.strip()) for p in paths)
-                return properties
-            else:
-                return [object.path_resolve(p.strip()) for p in paths]
+            properties = []
+            for obj in objects:
+                properties.extend(obj.path_resolve(p.strip()) for p in self.dataPaths.split(","))
+            return properties
         except:
             self.hasError = True
             return []
 
-    def getObject(self):
+    def getObjects(self):
         if self.idType == "OBJECT":
-            return self.object
+            if self.object is None: return []
+            return [self.object]
         elif self.idType == "COLLECTION":
-            return self.collection
+            if self.collection is None: return []
+            return self.collection.all_objects
         elif self.idType == "SCENE":
-            return self.scene
+            if self.scene is None: return []
+            return [self.scene]
 
     def draw(self, layout, index):
         box = layout.box()
@@ -79,12 +77,7 @@ class AutoExecutionTrigger_MonitorProperty(bpy.types.PropertyGroup):
         icon = 'TRIA_DOWN' if self.expanded else 'TRIA_RIGHT'
         header.prop(self, "expanded", icon = icon, text = "", emboss = False)
         if self.hasError: header.label(text = "", icon = "ERROR")
-
-        enableText = "Enable "
-        object = self.getObject()
-        if object is not None: enableText += object.name + "." + self.dataPaths
-        header.prop(self, "enabled", text = enableText, toggle = True)
-
+        header.prop(self, "enabled", text = "Enable " + self.dataPaths, toggle = True)
         header.operator("an.remove_auto_execution_trigger", icon = "X",
             text = "", emboss = False).index = index
 

--- a/animation_nodes/base_types/tree_auto_execution.py
+++ b/animation_nodes/base_types/tree_auto_execution.py
@@ -10,8 +10,11 @@ idTypeItems = [
 class AutoExecutionTrigger_MonitorProperty(bpy.types.PropertyGroup):
     bl_idname = "an_AutoExecutionTrigger_MonitorProperty"
 
+    def resetIDs(self, context):
+        self.object = self.collection = self.scene = None
+
     idType: EnumProperty(name = "ID Type", default = "OBJECT",
-        items = idTypeItems)
+        items = idTypeItems, update = resetIDs)
 
     object: PointerProperty(type = bpy.types.Object, name = "Object")
     collection: PointerProperty(type = bpy.types.Collection, name = "Collection")

--- a/animation_nodes/ui/auto_execution_panel.py
+++ b/animation_nodes/ui/auto_execution_panel.py
@@ -45,13 +45,11 @@ class AutoExecutionPanel(bpy.types.Panel):
 
         layout.prop(autoExecution, "minTimeDifference", slider = True)
 
-        col = layout.column()
-        col.operator("an.add_auto_execution_trigger", text = "New Trigger", icon = "ADD")
         customTriggers = autoExecution.customTriggers
-
-        subcol = col.column(align = True)
         for i, monitorPropertyTrigger in enumerate(customTriggers.monitorPropertyTriggers):
-            monitorPropertyTrigger.draw(subcol, i)
+            monitorPropertyTrigger.draw(layout, i)
+
+        layout.operator("an.add_auto_execution_trigger", text = "New Trigger", icon = "ADD")
 
     @classmethod
     def getTree(cls):


### PR DESCRIPTION
- The data path can now be a list of comma separated paths.
- Added a collection ID type where the the path is resolved for every object in the collection.
- The `triggerType` was partially removed for now since it is always constant.
- Execution Trigger UI and creation workflow have been redesigned. The trigger now defaults to object without a popup menu. Each trigger is now a UI box with a header that contains the minimize, the enable, and the remove buttons and a column that contains the ID type, the object selector, and the paths. The row-only structure was very crowded, small and uncomfortable to use. Here is how it looks:

![New UI](https://user-images.githubusercontent.com/25300994/54072262-1a3e0f80-4281-11e9-88d3-942ffddb8713.png)

The enable test is dynamic, it specifies which objects and which paths are monitored as you can see in the example above.

I was thinking of adding a way to let the user define the properties using a python expression. What do you think?


