### PR TITLE
 Fixed Material Output Node and renamed it to Workbench Material Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed *ReturnDefaultsOnExceptionCodeEffect* and *Get Struct* node.
 - Fixed the *fromFloatList* method of the *3DVectorList* structure.
 - Fixed double period in the description of some properties.
+- Fixed Material Output Node's Color output
 
 ### Changed
 
@@ -21,3 +22,4 @@
 - Allow multiple comma separated data paths per *Execution Trigger*.
 - Replaced colored icons in the *Node Menu* to be more uniform.
 - Started following Blender's class naming conventions.
+- Renamed *Material Output* to *Workbench Material Output*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,4 +22,3 @@
 - Allow multiple comma separated data paths per *Execution Trigger*.
 - Replaced colored icons in the *Node Menu* to be more uniform.
 - Started following Blender's class naming conventions.
-- Renamed *Material Output* to *Workbench Material Output*

--- a/animation_nodes/nodes/material/material_output.py
+++ b/animation_nodes/nodes/material/material_output.py
@@ -16,7 +16,7 @@ attributes = (
 
 class MaterialOutputNode(bpy.types.Node, AnimationNode):
     bl_idname = "an_MaterialOutputNode"
-    bl_label = "Workbench Material Output"
+    bl_label = "Material Output"
 
     def create(self):
         self.newInput("Material", "Material", "material", defaultDrawType = "PROPERTY_ONLY")

--- a/animation_nodes/nodes/material/material_output.py
+++ b/animation_nodes/nodes/material/material_output.py
@@ -16,7 +16,7 @@ attributes = (
 
 class MaterialOutputNode(bpy.types.Node, AnimationNode):
     bl_idname = "an_MaterialOutputNode"
-    bl_label = "Material Output"
+    bl_label = "Workbench Material Output"
 
     def create(self):
         self.newInput("Material", "Material", "material", defaultDrawType = "PROPERTY_ONLY")
@@ -38,10 +38,9 @@ class MaterialOutputNode(bpy.types.Node, AnimationNode):
             if self.inputs[i].isUsed: yield f"    self.{setFunction}(material, '{attr}', {attr})"
 
     def setAttribute_Color(self, material, attribute, color):
-        newColor = color[:3]
         oldColor = list(getattr(material, attribute))
-        if not all(isclose(a, b) for a, b in zip(oldColor, newColor)):
-            setattr(material, attribute, newColor)
+        if not all(isclose(a, b) for a, b in zip(oldColor, color)):
+            setattr(material, attribute, color)
 
     def setAttribute_Numeric(self, material, attribute, value):
         oldValue = getattr(material, attribute)

--- a/animation_nodes/ui/node_menu.py
+++ b/animation_nodes/ui/node_menu.py
@@ -513,7 +513,7 @@ class MaterialMenu(bpy.types.Menu):
         layout = self.layout
         insertNode(layout, "an_ObjectMaterialOutputNode", "Object Material Output")
         insertNode(layout, "an_CyclesMaterialOutputNode", "Cycles Material Output")
-        insertNode(layout, "an_MaterialOutputNode", "Workbench Material Output")
+        insertNode(layout, "an_MaterialOutputNode", "Material Output")
 
 class ParticleSystemMenu(bpy.types.Menu):
     bl_idname = "AN_MT_particle_system_menu"

--- a/animation_nodes/ui/node_menu.py
+++ b/animation_nodes/ui/node_menu.py
@@ -513,7 +513,7 @@ class MaterialMenu(bpy.types.Menu):
         layout = self.layout
         insertNode(layout, "an_ObjectMaterialOutputNode", "Object Material Output")
         insertNode(layout, "an_CyclesMaterialOutputNode", "Cycles Material Output")
-        insertNode(layout, "an_MaterialOutputNode", "Material Output")
+        insertNode(layout, "an_MaterialOutputNode", "Workbench Material Output")
 
 class ParticleSystemMenu(bpy.types.Menu):
     bl_idname = "AN_MT_particle_system_menu"


### PR DESCRIPTION
I'm redoing my pull requests with corrected dependencies.