### PR TITLE
Fix: Fails when try to rename an object

### DIFF
--- a/animation_nodes/sockets/object.py
+++ b/animation_nodes/sockets/object.py
@@ -43,10 +43,11 @@ class ObjectSocket(bpy.types.NodeSocket, AnimationNodeSocket):
 
     def handleEyedropperButton(self, event):
         if event.ctrl:
-            bpy.ops.an.rename_datablock_popup("INVOKE_DEFAULT",
-                oldName = self.object.name,
-                path = "bpy.data.objects",
-                icon = "OBJECT_DATA")
+            if self.object:
+                bpy.ops.an.rename_datablock_popup("INVOKE_DEFAULT",
+                    oldName = self.object.name,
+                    path = "bpy.data.objects",
+                    icon = "OBJECT_DATA")
         else:
             object = bpy.context.active_object
             if object: self.object = object


### PR DESCRIPTION
Fix for #1149.

This patch prevents the function of renaming if there is no object name.