### PR TITLE
fix baking for text object output

### DIFF
--- a/animation_nodes/nodes/text/text_object_output.py
+++ b/animation_nodes/nodes/text/text_object_output.py
@@ -137,4 +137,5 @@ class TextObjectOutputNode(bpy.types.Node, AnimationNode):
 
         if s["X Offset"].isUsed:            yield "    textObject.keyframe_insert('offset_x')"
         if s["Y Offset"].isUsed:            yield "    textObject.keyframe_insert('offset_y')"
-        if s["Align"].isUsed:               yield "    textObject.keyframe_insert('align')"
+        if s["Horizontal Align"].isUsed:    yield "    textObject.keyframe_insert('align_x')"
+        if s["Vertical Align"].isUsed:      yield "    textObject.keyframe_insert('align_y')"


### PR DESCRIPTION
Before, this crashed because the key "Align" does not exist.