### PR TITLE
Wiggle Falloff: use double math to avoid precision problems (#1164)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed *Create Execution Trigger* operators.
 - Fixed *getSelectedObjectNames* function.
 - Fixed the *Offset Vertices* and *Offset Polygons* nodes. Copy the input mesh if needed.
+- Fixed a stepping/precision problem in *Wiggle Falloff*.
 
 ### Changed
 

--- a/animation_nodes/nodes/falloff/wiggle_falloff.pyx
+++ b/animation_nodes/nodes/falloff/wiggle_falloff.pyx
@@ -25,15 +25,15 @@ class WiggleFalloffNode(bpy.types.Node, AnimationNode):
 
 cdef class WiggleFalloff(BaseFalloff):
     cdef:
-        float evolution
-        float offset, amplitude
-        float persistance
+        double evolution
+        double offset, amplitude
+        double persistance
         int octaves
 
     def __cinit__(self, float seed, float evolution,
                         float offset, float amplitude,
                         int octaves, float persistance):
-        self.evolution = seed * 3413123 + evolution
+        self.evolution = seed * 341312 + evolution
         self.amplitude = amplitude
         self.persistance = persistance
         self.offset = offset
@@ -42,6 +42,6 @@ cdef class WiggleFalloff(BaseFalloff):
         self.dataType = "None"
 
     cdef float evaluate(self, void *object, Py_ssize_t index):
-        cdef float x = self.evolution + index * 1127
-        cdef float noise = perlinNoise1D(x, self.persistance, self.octaves)
-        return self.amplitude * noise + self.offset
+        cdef double x = self.evolution + index * 1127
+        cdef double noise = perlinNoise1D(x, self.persistance, self.octaves)
+        return <float>(self.amplitude * noise + self.offset)


### PR DESCRIPTION
This is a straightforward fix to #1164 which just converts all the float math to double (and reduces the size of the constant multiplier) in order to avoid hitting precision issues. We cast back to float right at the end, instead.