### PR TITLE
cleanup header ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed *getSelectedObjectNames* function.
 - Fixed the *Offset Vertices* and *Offset Polygons* nodes. Copy the input mesh if needed.
 - Fixed a stepping/precision problem in *Wiggle Falloff*.
+- Fixed header alignment for Subprograms menu and Remove nodetree operator in AN Nodetree area.
 
 ### Changed
 

--- a/animation_nodes/ui/header.py
+++ b/animation_nodes/ui/header.py
@@ -1,14 +1,17 @@
 import bpy
 
-class TemplatesMenuInHeader(bpy.types.Header):
-    bl_idname = "AN_HT_templates_menu_in_header"
-    bl_space_type = "NODE_EDITOR"
+def subprograms_menu_callback(self, context):
+    if context.space_data.tree_type != "an_AnimationNodeTree": return
+    self.layout.menu("AN_MT_subprograms_menu", text="Subprograms")
 
-    def draw(self, context):
-        if context.space_data.tree_type != "an_AnimationNodeTree": return
+def remove_nodetree_callback(self, context):
+    if context.space_data.tree_type != "an_AnimationNodeTree": return
+    self.layout.operator("an.remove_node_tree", text="Remove", icon="CANCEL")
 
-        layout = self.layout
-        layout.separator()
-        layout.menu("AN_MT_subprograms_menu", text = "Subprograms")
+def register():
+    bpy.types.NODE_MT_editor_menus.append(subprograms_menu_callback)
+    bpy.types.NODE_HT_header.append(remove_nodetree_callback)
 
-        layout.operator("an.remove_node_tree", text = "Remove", emboss = False)
+def unregister():
+    bpy.types.NODE_MT_editor_menus.remove(subprograms_menu_callback)
+    bpy.types.NODE_HT_header.remove(remove_nodetree_callback)


### PR DESCRIPTION
not perfect but allows to keep alignment and readability of Subprograms menu and Remove An nodetree operator (which is now aligned to the right of the header)