### PR TITLE
Fixed the Zero Division Error.

### DIFF
--- a/animation_nodes/data_structures/splines/base_spline.pyx
+++ b/animation_nodes/data_structures/splines/base_spline.pyx
@@ -1,7 +1,7 @@
 from ... utils.lists cimport findListSegment_LowLevel
 from ... math cimport (
     distanceSquaredVec3, crossVec3, projectOnCenterPlaneVec3,
-    almostZeroVec3, lengthVec3, angleVec3, dotVec3, normalizeVec3_InPlace,
+    almostZeroVec3, angleVec3, dotVec3, normalizeVec3_InPlace,
     toPyVector3, toVector3,
     findNearestLineParameter,
     distanceSumOfVector3DList,
@@ -491,13 +491,7 @@ cdef void setInitialNormal(Vector3 *tangent, Vector3 *target):
 cdef void calcNextNormal(Vector3 *target, Vector3 *lastNormal, Vector3 *lastTangent, Vector3 *currentTangent):
     cdef Vector3 axis
     crossVec3(&axis, lastTangent, currentTangent)
-
-    cdef float angle
-    if lengthVec3(lastTangent) == 0 or lengthVec3(currentTangent) == 0:
-        angle = 0
-    else:
-        angle = angleVec3(lastTangent, currentTangent)
-
+    cdef float angle = angleVec3(lastTangent, currentTangent)
     cdef Vector3 newNormal
     rotateAroundAxisVec3(&newNormal, lastNormal, &axis, angle)
     projectOnCenterPlaneVec3(target, &newNormal, currentTangent)

--- a/animation_nodes/data_structures/splines/base_spline.pyx
+++ b/animation_nodes/data_structures/splines/base_spline.pyx
@@ -1,7 +1,7 @@
 from ... utils.lists cimport findListSegment_LowLevel
 from ... math cimport (
     distanceSquaredVec3, crossVec3, projectOnCenterPlaneVec3,
-    almostZeroVec3, angleVec3, dotVec3, normalizeVec3_InPlace,
+    almostZeroVec3, lengthVec3, angleVec3, dotVec3, normalizeVec3_InPlace,
     toPyVector3, toVector3,
     findNearestLineParameter,
     distanceSumOfVector3DList,
@@ -491,7 +491,13 @@ cdef void setInitialNormal(Vector3 *tangent, Vector3 *target):
 cdef void calcNextNormal(Vector3 *target, Vector3 *lastNormal, Vector3 *lastTangent, Vector3 *currentTangent):
     cdef Vector3 axis
     crossVec3(&axis, lastTangent, currentTangent)
-    cdef float angle = angleVec3(lastTangent, currentTangent)
+
+    cdef float angle
+    if lengthVec3(lastTangent) == 0 or lengthVec3(currentTangent) == 0:
+        angle = 0
+    else:
+        angle = angleVec3(lastTangent, currentTangent)
+
     cdef Vector3 newNormal
     rotateAroundAxisVec3(&newNormal, lastNormal, &axis, angle)
     projectOnCenterPlaneVec3(target, &newNormal, currentTangent)

--- a/animation_nodes/math/vector.pyx
+++ b/animation_nodes/math/vector.pyx
@@ -120,14 +120,11 @@ cdef float dotVec3(Vector3* a, Vector3* b):
 
 @cython.cdivision(True)
 cdef float angleVec3(Vector3 *a, Vector3 *b):
+    cdef float denominator = lengthVec3(a) * lengthVec3(b)
+    if denominator == 0: return 0
+
     cdef float dot = dotVec3(a, b)
-    cdef float val, lengthVecA, lengthVecB
-    lengthVecA = lengthVec3(a)
-    lengthVecB = lengthVec3(b)
-    if lengthVecA == 0 or lengthVecB == 0:
-        val = 0
-    else:
-        val = dot / (lengthVecA * lengthVecB)
+    cdef float val = dot / denominator
     if val > 1: val = 1
     elif val < -1: val = -1
     return acos(val)

--- a/animation_nodes/math/vector.pyx
+++ b/animation_nodes/math/vector.pyx
@@ -118,6 +118,7 @@ cdef float distanceSquaredVec3(Vector3* a, Vector3* b):
 cdef float dotVec3(Vector3* a, Vector3* b):
     return a.x * b.x + a.y * b.y + a.z * b.z
 
+@cython.cdivision(True)
 cdef float angleVec3(Vector3 *a, Vector3 *b):
     cdef float dot = dotVec3(a, b)
     cdef float val

--- a/animation_nodes/math/vector.pyx
+++ b/animation_nodes/math/vector.pyx
@@ -121,8 +121,13 @@ cdef float dotVec3(Vector3* a, Vector3* b):
 @cython.cdivision(True)
 cdef float angleVec3(Vector3 *a, Vector3 *b):
     cdef float dot = dotVec3(a, b)
-    cdef float val
-    val = dot / (lengthVec3(a) * lengthVec3(b))
+    cdef float val, lengthVecA, lengthVecB
+    lengthVecA = lengthVec3(a)
+    lengthVecB = lengthVec3(b)
+    if lengthVecA == 0 or lengthVecB == 0:
+        val = 0
+    else:
+        val = dot / (lengthVecA * lengthVecB)
     if val > 1: val = 1
     elif val < -1: val = -1
     return acos(val)


### PR DESCRIPTION
Fixed the "ZeroDivisionError" showed by animation nodes in Blender2.83,
![Screenshot from 2020-01-19 21-57-27](https://user-images.githubusercontent.com/30294746/72685010-d015f380-3b0b-11ea-9e8f-fe512f080b35.png)

I have found that `@cython.cdivision(True)` is not written which gave the error,
https://github.com/JacquesLucke/animation_nodes/blob/2d7ddbc18a0fcf9056c191fea12a208e4afa0f36/animation_nodes/math/vector.pyx#L120-L124