### PR TITLE
Added the __repr__ function in bezier_spline.pyx and poly_spline.pyx.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Vectorized Set Vertex Color node and color modes are added.
 - Linux and MacOS are now release builds. They were debug builds.
 - Added Points mode to the Line Mesh node.
+- Added the `__repr__` function for spline.
 
 ## 2.1.5
 

--- a/animation_nodes/data_structures/splines/bezier_spline.pyx
+++ b/animation_nodes/data_structures/splines/bezier_spline.pyx
@@ -45,7 +45,7 @@ cdef class BezierSpline(Spline):
     def __repr__(self):
         return textwrap.dedent(
         f"""AN Spline Object:
-        Total Points: {self.points.length}
+        Points: {self.points.length}
         Type: {self.type}
         Cyclic: {self.cyclic}""")
 

--- a/animation_nodes/data_structures/splines/bezier_spline.pyx
+++ b/animation_nodes/data_structures/splines/bezier_spline.pyx
@@ -1,4 +1,5 @@
 cimport cython
+import textwrap
 from libc.string cimport memcpy
 from numpy.polynomial import Polynomial
 from ... utils.lists cimport findListSegment_LowLevel
@@ -40,6 +41,13 @@ cdef class BezierSpline(Spline):
         self.cyclic = cyclic
         self.type = "BEZIER"
         self.markChanged()
+
+    def __repr__(self):
+        return textwrap.dedent(
+        f"""AN Spline Object:
+        Total Points: {self.points.length}
+        Type: {self.type}
+        Cyclic: {self.cyclic}""")
 
     cpdef void markChanged(self):
         Spline.markChanged(self)

--- a/animation_nodes/data_structures/splines/poly_spline.pyx
+++ b/animation_nodes/data_structures/splines/poly_spline.pyx
@@ -33,7 +33,7 @@ cdef class PolySpline(Spline):
     def __repr__(self):
         return textwrap.dedent(
         f"""AN Spline Object:
-        Total Points: {self.points.length}
+        Points: {self.points.length}
         Type: {self.type}
         Cyclic: {self.cyclic}""")
 

--- a/animation_nodes/data_structures/splines/poly_spline.pyx
+++ b/animation_nodes/data_structures/splines/poly_spline.pyx
@@ -1,4 +1,5 @@
 cimport cython
+import textwrap
 from libc.math cimport floor
 from libc.string cimport memcpy
 from . base_spline import calculateNormalsForTangents
@@ -28,6 +29,13 @@ cdef class PolySpline(Spline):
         self.tilts = tilts
         self.cyclic = cyclic
         self.markChanged()
+
+    def __repr__(self):
+        return textwrap.dedent(
+        f"""AN Spline Object:
+        Total Points: {self.points.length}
+        Type: {self.type}
+        Cyclic: {self.cyclic}""")
 
     cpdef void markChanged(self):
         Spline.markChanged(self)


### PR DESCRIPTION
I have added the `__repr__` function in `bezier_spline.pyx` and `poly_spline.pyx` to get information about the spline with the _Viewer Node_. Here is an example,
![Screenshot from 2020-01-27 12-25-54](https://user-images.githubusercontent.com/30294746/73155282-38626780-4100-11ea-94be-19665378a9d6.png)
