### PR TITLE
Fixed the Distribute Matrices node for the Spiral option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fixed the Splines From Branches algorithm for closed loops.
 - Fixed auto execution when the node tree is refreshed during animation.
+- Fixed the Distribute Matrices node for the Spiral option.
 
 ### Changed
 

--- a/animation_nodes/nodes/matrix/distribute_matrices.pyx
+++ b/animation_nodes/nodes/matrix/distribute_matrices.pyx
@@ -224,7 +224,7 @@ class DistributeMatricesNode(bpy.types.Node, AnimationNode):
         cdef float iCos, iSin, stepCos, stepSin, f, size
         cdef Matrix4x4List matrices = Matrix4x4List(length = amount)
         cdef float factor = 1 / <float>(amount - 1) if amount > 1 else 0
-        cdef float angleStep = (endAngle - startAngle) / (amount - 1)
+        cdef float angleStep = (endAngle - startAngle) / (amount - 1) if amount > 1 else 0
 
         iCos = cos(startAngle)
         iSin = sin(startAngle)


### PR DESCRIPTION
The _Distribute Matrices_ node with the _Spiral_ break the node-tree when _Amount = 1_ and gives this error,
![Screenshot from 2020-02-09 02-48-57](https://user-images.githubusercontent.com/30294746/74092227-00d3c200-4ae7-11ea-8c3a-2e3d1fbf369e.png)
Now, it is fixed in this branch.

