### PR TITLE
Added the Tint Color, Factor and Stroke Thickness attributes to GP Layer object

### DIFF
--- a/animation_nodes/data_structures/gpencils/gp_layer_data.py
+++ b/animation_nodes/data_structures/gpencils/gp_layer_data.py
@@ -1,10 +1,14 @@
 import textwrap
+from .. color import Color
 
 class GPLayer:
     def __init__(self, layerName = None,
                        frames = None,
                        blendMode = None,
                        opacity = None,
+                       tintColor = None,
+                       tintFactor = None,
+                       lineChange = None,
                        passIndex = None,
                        maskLayer = None):
 
@@ -12,6 +16,9 @@ class GPLayer:
         if frames is None: frames = []
         if blendMode is None: blendMode = "REGULAR"
         if opacity is None: opacity = 1
+        if tintColor is None: tintColor = Color((0, 0, 0, 0))
+        if tintFactor is None: tintFactor = 0
+        if lineChange is None: lineChange = 0
         if passIndex is None: passIndex = 0
         if maskLayer is None: maskLayer = False
 
@@ -19,9 +26,12 @@ class GPLayer:
         self.layerName = layerName
         self.blendMode = blendMode
         self.opacity = opacity
+        self.tintColor = tintColor
+        self.tintFactor = tintFactor
+        self.lineChange = lineChange
         self.passIndex = passIndex
         self.maskLayer = maskLayer
-        
+
     def __repr__(self):
         return textwrap.dedent(
         f"""AN Layer Object:
@@ -29,9 +39,13 @@ class GPLayer:
         Frames: {len(self.frames)}
         Blend Mode: {self.blendMode}
         Opacity: {self.opacity}
+        Tint Color: {self.tintColor}
+        Factor: {self.tintFactor}
+        Stroke Thickness: {self.lineChange}
         Pass Index: {self.passIndex}
         Mask Layer: {self.maskLayer}""")
 
     def copy(self):
         return GPLayer(self.layerName, [frame.copy() for frame in self.frames],
-                       self.blendMode, self.opacity, self.passIndex, self.maskLayer)
+                       self.blendMode, self.opacity, self.tintColor, self.tintFactor,
+                       self.lineChange, self.passIndex, self.maskLayer)

--- a/animation_nodes/data_structures/gpencils/gp_layer_data.py
+++ b/animation_nodes/data_structures/gpencils/gp_layer_data.py
@@ -40,7 +40,7 @@ class GPLayer:
         Blend Mode: {self.blendMode}
         Opacity: {self.opacity}
         Tint Color: {self.tintColor}
-        Factor: {self.tintFactor}
+        Tint Factor: {self.tintFactor}
         Stroke Thickness: {self.lineChange}
         Pass Index: {self.passIndex}
         Mask Layer: {self.maskLayer}""")

--- a/animation_nodes/nodes/gpencil/gp_layer_from_frames.py
+++ b/animation_nodes/nodes/gpencil/gp_layer_from_frames.py
@@ -18,7 +18,7 @@ class GPLayerFromFramesNode(bpy.types.Node, AnimationNode):
         self.newInput("Text", "Blend Mode", "blendMode", value = 'REGULAR', hide = True)
         self.newInput("Float", "Opacity", "opacity", value = 1, minValue = 0, maxValue = 1, hide = True)
         self.newInput("Color", "Tint Color", "tintColor", hide = True)
-        self.newInput("Float", "Factor", "tintFactor", value = 0, minValue = 0, maxValue = 1, hide = True)
+        self.newInput("Float", "Tint Factor", "tintFactor", value = 0, minValue = 0, maxValue = 1, hide = True)
         self.newInput("Float", "Stroke Thickness", "lineChange", hide = True)
         self.newInput("Integer", "Pass Index", "passIndex", value = 0, minValue = 0, hide = True)
         self.newInput("Boolean", "Mask Layer", "maskLayer", value = False, hide = True)

--- a/animation_nodes/nodes/gpencil/gp_layer_from_frames.py
+++ b/animation_nodes/nodes/gpencil/gp_layer_from_frames.py
@@ -16,12 +16,15 @@ class GPLayerFromFramesNode(bpy.types.Node, AnimationNode):
             ("Frame", "frame"), ("Frames", "frames")), dataIsModified = True)
         self.newInput("Text", "Name", "layerName", value = 'AN-Layer')
         self.newInput("Text", "Blend Mode", "blendMode", value = 'REGULAR', hide = True)
-        self.newInput("Float", "Opacity", "opacity", value = 1, hide = True)
-        self.newInput("Integer", "Pass Index", "passIndex", value = 0, hide = True)
+        self.newInput("Float", "Opacity", "opacity", value = 1, minValue = 0, maxValue = 1, hide = True)
+        self.newInput("Color", "Tint Color", "tintColor", hide = True)
+        self.newInput("Float", "Factor", "tintFactor", value = 0, minValue = 0, maxValue = 1, hide = True)
+        self.newInput("Float", "Stroke Thickness", "lineChange", hide = True)
+        self.newInput("Integer", "Pass Index", "passIndex", value = 0, minValue = 0, hide = True)
         self.newInput("Boolean", "Mask Layer", "maskLayer", value = False, hide = True)
         self.newOutput("GPLayer", "Layer", "layer")
 
-    def execute(self, frames, layerName, blendMode, opacity, passIndex, maskLayer):
+    def execute(self, frames, layerName, blendMode, opacity, tintColor, tintFactor, lineChange, passIndex, maskLayer):
         if not self.useFrameList:
             frames = [frames]
 
@@ -30,4 +33,4 @@ class GPLayerFromFramesNode(bpy.types.Node, AnimationNode):
             self.raiseErrorMessage("Some Frame Numbers are repeated.")
         if blendMode not in ['REGULAR', 'OVERLAY', 'ADD', 'SUBTRACT', 'MULTIPLY', 'DIVIDE']:
             self.raiseErrorMessage("The blend mode is invalid. \n\nPossible values for 'Blend Mode' are: 'REGULAR', 'OVERLAY', 'ADD', 'SUBTRACT', 'MULTIPLY', 'DIVIDE'")
-        return GPLayer(layerName, frames, blendMode, opacity, passIndex, maskLayer)
+        return GPLayer(layerName, frames, blendMode, opacity, tintColor, tintFactor, lineChange, passIndex, maskLayer)

--- a/animation_nodes/nodes/gpencil/gp_layer_info.py
+++ b/animation_nodes/nodes/gpencil/gp_layer_info.py
@@ -47,7 +47,7 @@ class GPLayerInfoNode(bpy.types.Node, AnimationNode):
         self.newOutput("Text", "Blend Mode", "blendMode", hide = True)
         self.newOutput("Float", "Opacity", "opacity", hide = True)
         self.newOutput("Color", "Tint Color", "tintColor", hide = True)
-        self.newOutput("Float", "Factor", "tintFactor", hide = True)
+        self.newOutput("Float", "Tint Factor", "tintFactor", hide = True)
         self.newOutput("Float", "Stroke Thickness", "lineChange", hide = True)
         self.newOutput("Integer", "Pass Index", "passIndex", hide = True)
         self.newOutput("Boolean", "Mask Layer", "maskLayer", hide = True)

--- a/animation_nodes/nodes/gpencil/gp_layer_info.py
+++ b/animation_nodes/nodes/gpencil/gp_layer_info.py
@@ -46,6 +46,9 @@ class GPLayerInfoNode(bpy.types.Node, AnimationNode):
         self.newOutput("Text", "Name", "layerName", hide = True)
         self.newOutput("Text", "Blend Mode", "blendMode", hide = True)
         self.newOutput("Float", "Opacity", "opacity", hide = True)
+        self.newOutput("Color", "Tint Color", "tintColor", hide = True)
+        self.newOutput("Float", "Factor", "tintFactor", hide = True)
+        self.newOutput("Float", "Stroke Thickness", "lineChange", hide = True)
         self.newOutput("Integer", "Pass Index", "passIndex", hide = True)
         self.newOutput("Boolean", "Mask Layer", "maskLayer", hide = True)
 
@@ -71,46 +74,57 @@ class GPLayerInfoNode(bpy.types.Node, AnimationNode):
     def execute_ActiveFrame(self, layer, scene):
         frames = layer.frames
         if len(frames) == 0:
-            return GPFrame(), layer.layerName, layer.blendMode, layer.opacity, layer.passIndex, layer.maskLayer
+            return (GPFrame(), layer.layerName, layer.blendMode, layer.opacity, layer.tintColor,
+                    layer.tintFactor, layer.lineChange, layer.passIndex, layer.maskLayer)
 
         return (self.getActiveFrame(scene.frame_current, frames), layer.layerName, layer.blendMode,
-                layer.opacity, layer.passIndex, layer.maskLayer)
+                layer.opacity, layer.tintColor, layer.tintFactor, layer.lineChange, layer.passIndex,
+                layer.maskLayer)
 
     def execute_FrameIndex(self, layer, frameIndex):
         frames = layer.frames
         if len(frames) == 0:
-            return GPFrame(), layer.layerName, layer.blendMode, layer.opacity, layer.passIndex, layer.maskLayer
+            return (GPFrame(), layer.layerName, layer.blendMode, layer.opacity, layer.tintColor,
+                    layer.tintFactor, layer.lineChange, layer.passIndex, layer.maskLayer)
 
         frame = self.getFrame(frames, frameIndex)
-        return frame, layer.layerName, layer.blendMode, layer.opacity, layer.passIndex, layer.maskLayer
+        return (frame, layer.layerName, layer.blendMode, layer.opacity, layer.tintColor,
+                layer.tintFactor, layer.lineChange, layer.passIndex, layer.maskLayer)
 
     def execute_FrameIndices(self, layer, frameIndices):
         frames = layer.frames
         if len(frames) == 0:
-            return [], layer.layerName, layer.blendMode, layer.opacity, layer.passIndex, layer.maskLayer
+            return ([], layer.layerName, layer.blendMode, layer.opacity, layer.tintColor,
+                    layer.tintFactor, layer.lineChange, layer.passIndex, layer.maskLayer)
 
         outFrames = [self.getFrame(frames, index) for index in frameIndices]
-        return outFrames, layer.layerName, layer.blendMode, layer.opacity, layer.passIndex, layer.maskLayer
+        return (outFrames, layer.layerName, layer.blendMode, layer.opacity, layer.tintColor,
+                layer.tintFactor, layer.lineChange, layer.passIndex, layer.maskLayer)
 
     def execute_FrameNumber(self, layer, frameNumber):
         frames = layer.frames
         if len(frames) == 0:
-            return GPFrame(), layer.layerName, layer.blendMode, layer.opacity, layer.passIndex, layer.maskLayer
+            return (GPFrame(), layer.layerName, layer.blendMode, layer.opacity, layer.tintColor,
+                    layer.tintFactor, layer.lineChange, layer.passIndex, layer.maskLayer)
 
         return (self.getFrameFromNumber(frames, frameNumber), layer.layerName, layer.blendMode,
-                layer.opacity, layer.passIndex, layer.maskLayer)
+                layer.opacity, layer.tintColor, layer.tintFactor, layer.lineChange, layer.passIndex,
+                layer.maskLayer)
 
     def execute_FrameNumbers(self, layer, inFrameNumbers):
         frames = layer.frames
         if len(frames) == 0:
-            return [], layer.layerName, layer.blendMode, layer.opacity, layer.passIndex, layer.maskLayer
+            return ([], layer.layerName, layer.blendMode, layer.opacity, layer.tintColor,
+                    layer.tintFactor, layer.lineChange, layer.passIndex, layer.maskLayer)
 
         outFrames = [self.getFrameFromNumber(frames, frameNumber) for frameNumber in inFrameNumbers]
-        return outFrames, layer.layerName, layer.blendMode, layer.opacity, layer.passIndex, layer.maskLayer
+        return (outFrames, layer.layerName, layer.blendMode, layer.opacity, layer.tintColor,
+                layer.tintFactor, layer.lineChange, layer.passIndex, layer.maskLayer)
 
     def execute_AllFrames(self, layer):
         frames = layer.frames
-        return frames, layer.layerName, layer.blendMode, layer.opacity, layer.passIndex, layer.maskLayer
+        return (frames, layer.layerName, layer.blendMode, layer.opacity, layer.tintColor,
+                layer.tintFactor, layer.lineChange, layer.passIndex, layer.maskLayer)
 
     def getActiveFrame(self, currentFrame, frames):
         return max((frame for frame in frames if frame.frameNumber <= currentFrame),

--- a/animation_nodes/nodes/gpencil/gp_object_input.py
+++ b/animation_nodes/nodes/gpencil/gp_object_input.py
@@ -43,8 +43,9 @@ class GPObjectInputNode(bpy.types.Node, AnimationNode):
 
         evaluatedObject = getEvaluatedID(object)
         layer = self.getLayer(evaluatedObject, layerName)
-        return GPLayer(layer.info, self.getFrames(layer, evaluatedObject, useWorldSpace), layer.blend_mode,
-                       layer.opacity, layer.pass_index, layer.mask_layer)
+        return GPLayer(layer.info, self.getFrames(layer, evaluatedObject, useWorldSpace),
+                       layer.blend_mode, layer.opacity, layer.tint_color, layer.tint_factor,
+                       layer.line_change, layer.pass_index, layer.mask_layer)
 
     def executeList(self, object, useWorldSpace):
         if object is None:
@@ -54,7 +55,8 @@ class GPObjectInputNode(bpy.types.Node, AnimationNode):
         gpencilLayers = []
         for layer in self.getLayers(evaluatedObject):
             gpencilLayers.append(GPLayer(layer.info, self.getFrames(layer, evaluatedObject, useWorldSpace),
-                                         layer.blend_mode, layer.opacity, layer.pass_index, layer.mask_layer))
+                                         layer.blend_mode, layer.opacity, layer.tint_color, layer.tint_factor,
+                                         layer.line_change, layer.pass_index, layer.mask_layer))
         return gpencilLayers
 
     def getLayer(self, object, layerName):

--- a/animation_nodes/nodes/gpencil/gp_object_output.py
+++ b/animation_nodes/nodes/gpencil/gp_object_output.py
@@ -84,6 +84,9 @@ class GPObjectOutputNode(bpy.types.Node, AnimationNode):
             gpencilLayer = gpencil.layers.new(layerName, set_active = True)
         gpencilLayer.blend_mode = layer.blendMode
         gpencilLayer.opacity = layer.opacity
+        gpencilLayer.tint_color = layer.tintColor[:3]
+        gpencilLayer.tint_factor = layer.tintFactor
+        gpencilLayer.line_change = layer.lineChange
         gpencilLayer.pass_index = layer.passIndex
         gpencilLayer.mask_layer = layer.maskLayer
         return gpencilLayer

--- a/animation_nodes/nodes/gpencil/replicate_gp_layer.py
+++ b/animation_nodes/nodes/gpencil/replicate_gp_layer.py
@@ -32,7 +32,7 @@ class ReplicateGPLayerNode(bpy.types.Node, AnimationNode):
         self.newInput(VectorizedSocket("Color", "useTintColorList",
             ("Tint Color", "tintColors"), ("Tint Colors", "tintColors")), hide = True)
         self.newInput(VectorizedSocket("Float", "useTintFactorList",
-            ("Factor", "tintFactors"), ("Factors", "tintFactors")), value = 0, hide = True)
+            ("Tint Factor", "tintFactors"), ("Tint Factors", "tintFactors")), value = 0, hide = True)
         self.newInput(VectorizedSocket("Float", "useLineChangeList",
             ("Stroke Thickness", "lineChanges"), ("Stroke Thicknesses", "lineChanges")), value = 0, hide = True)
 

--- a/animation_nodes/nodes/gpencil/replicate_gp_layer.py
+++ b/animation_nodes/nodes/gpencil/replicate_gp_layer.py
@@ -1,8 +1,8 @@
 import bpy
 from bpy.props import *
 from mathutils import Matrix
-from ... data_structures import GPLayer, VirtualDoubleList
 from ... base_types import AnimationNode, VectorizedSocket
+from ... data_structures import GPLayer, Color, VirtualDoubleList, VirtualLongList, VirtualColorList
 
 transformationTypeItems = [
     ("Matrix List", "Matrices", "", "NONE", 0),
@@ -13,11 +13,14 @@ class ReplicateGPLayerNode(bpy.types.Node, AnimationNode):
     bl_idname = "an_ReplicateGPLayerNode"
     bl_label = "Replicate GP Layer"
 
-    useLayerList: VectorizedSocket.newProperty()
-    useOffsetList: VectorizedSocket.newProperty()
-
     transformationType: EnumProperty(name = "Transformation Type", default = "Matrix List",
         items = transformationTypeItems, update = AnimationNode.refresh)
+
+    useLayerList: VectorizedSocket.newProperty()
+    useOffsetList: VectorizedSocket.newProperty()
+    useTintColorList: VectorizedSocket.newProperty()
+    useTintFactorList: VectorizedSocket.newProperty()
+    useLineChangeList: VectorizedSocket.newProperty()
 
     def create(self):
         self.newInput(VectorizedSocket("GPLayer", "useLayerList",
@@ -26,6 +29,12 @@ class ReplicateGPLayerNode(bpy.types.Node, AnimationNode):
         self.newInput(self.transformationType, "Transformations", "transformations")
         self.newInput(VectorizedSocket("Float", "useOffsetList",
             ("Offset Frame", "offsets"), ("Offset Frames", "offsets")), value = 0, hide = True)
+        self.newInput(VectorizedSocket("Color", "useTintColorList",
+            ("Tint Color", "tintColors"), ("Tint Colors", "tintColors")), hide = True)
+        self.newInput(VectorizedSocket("Float", "useTintFactorList",
+            ("Factor", "tintFactors"), ("Factors", "tintFactors")), value = 0, hide = True)
+        self.newInput(VectorizedSocket("Float", "useLineChangeList",
+            ("Stroke Thickness", "lineChanges"), ("Stroke Thicknesses", "lineChanges")), value = 0, hide = True)
 
         self.newOutput("GPLayer List", "Layers", "outLayers")
 
@@ -38,32 +47,44 @@ class ReplicateGPLayerNode(bpy.types.Node, AnimationNode):
         elif self.transformationType == "Vector List":
             return "execute_VectorList"
 
-    def execute_MatrixList(self, layers, matrices, offsets):
+    def execute_MatrixList(self, layers, matrices, offsets, tintColors, tintFactors, lineChanges):
         if isinstance(layers, GPLayer):
             layers = [layers]
 
         _offsets = VirtualDoubleList.create(offsets, 0)
+        _tintColors = VirtualColorList.create(tintColors, Color((0, 0, 0, 0)))
+        _tintFactors = VirtualDoubleList.create(tintFactors, 0)
+        _lineChanges = VirtualDoubleList.create(lineChanges, 0)
 
         outLayers = []
         for i, matrix in enumerate(matrices):
             for layer in layers:
                 newLayer = layer.copy()
                 newLayer.layerName = layer.layerName + "-" + str(i)
+                newLayer.tintColor = _tintColors[i]
+                newLayer.tintFactor = _tintFactors[i]
+                newLayer.lineChange = _lineChanges[i]
                 self.transformLayerByMatrix(newLayer, _offsets[i], matrix)
                 outLayers.append(newLayer)
         return outLayers
 
-    def execute_VectorList(self, layers, vectors, offsets):
+    def execute_VectorList(self, layers, vectors, offsets, tintColors, tintFactors, lineChanges):
         if isinstance(layers, GPLayer):
             layers = [layers]
 
         _offsets = VirtualDoubleList.create(offsets, 0)
+        _tintColors = VirtualColorList.create(tintColors, Color((0, 0, 0, 0)))
+        _tintFactors = VirtualDoubleList.create(tintFactors, 0)
+        _lineChanges = VirtualDoubleList.create(lineChanges, 0)
 
         outLayers = []
         for i, vector in enumerate(vectors):
             for layer in layers:
                 newLayer = layer.copy()
                 newLayer.layerName = layer.layerName + "-" + str(i)
+                newLayer.tintColor = _tintColors[i]
+                newLayer.tintFactor = _tintFactors[i]
+                newLayer.lineChange = _lineChanges[i]
                 self.transformLayerByVector(newLayer, _offsets[i], vector)
                 outLayers.append(newLayer)
         return outLayers

--- a/animation_nodes/nodes/gpencil/set_gp_layer_attributes.py
+++ b/animation_nodes/nodes/gpencil/set_gp_layer_attributes.py
@@ -30,7 +30,7 @@ class SetGPLayerAttributesNode(bpy.types.Node, AnimationNode):
         self.newInput(VectorizedSocket("Color", "useTintColorList",
             ("Tint Color", "tintColors"), ("Tint Colors", "tintColors")), hide = True)
         self.newInput(VectorizedSocket("Float", "useTintFactorList",
-            ("Factor", "tintFactors"), ("Factors", "tintFactors")), value = 0, minValue = 0, maxValue = 1, hide = True)
+            ("Tint Factor", "tintFactors"), ("Tint Factors", "tintFactors")), value = 0, minValue = 0, maxValue = 1, hide = True)
         self.newInput(VectorizedSocket("Float", "useLineChangeList",
             ("Stroke Thickness", "lineChanges"), ("Stroke Thicknesses", "lineChanges")), hide = True)
         self.newInput(VectorizedSocket("Integer", "usePassIndexList",

--- a/animation_nodes/nodes/gpencil/set_gp_layer_attributes.py
+++ b/animation_nodes/nodes/gpencil/set_gp_layer_attributes.py
@@ -12,6 +12,9 @@ class SetGPLayerAttributesNode(bpy.types.Node, AnimationNode):
     useNameList: VectorizedSocket.newProperty()
     useBlendModeList: VectorizedSocket.newProperty()
     useOpacityList: VectorizedSocket.newProperty()
+    useTintColorList: VectorizedSocket.newProperty()
+    useTintFactorList: VectorizedSocket.newProperty()
+    useLineChangeList: VectorizedSocket.newProperty()
     usePassIndexList: VectorizedSocket.newProperty()
     useMaskLayerList: VectorizedSocket.newProperty()
 
@@ -24,13 +27,20 @@ class SetGPLayerAttributesNode(bpy.types.Node, AnimationNode):
             ("Blend Mode", "blendModes"), ("Blend Modes", "blendModes")), value = 'REGULAR', hide = True)
         self.newInput(VectorizedSocket("Float", "useOpacityList",
             ("Opacity", "opacities"), ("Opacities", "opacities")), value = 1, minValue = 0, maxValue = 1)
+        self.newInput(VectorizedSocket("Color", "useTintColorList",
+            ("Tint Color", "tintColors"), ("Tint Colors", "tintColors")), hide = True)
+        self.newInput(VectorizedSocket("Float", "useTintFactorList",
+            ("Factor", "tintFactors"), ("Factors", "tintFactors")), value = 0, minValue = 0, maxValue = 1, hide = True)
+        self.newInput(VectorizedSocket("Float", "useLineChangeList",
+            ("Stroke Thickness", "lineChanges"), ("Stroke Thicknesses", "lineChanges")), hide = True)
         self.newInput(VectorizedSocket("Integer", "usePassIndexList",
             ("Pass Index", "passIndices"), ("Pass Indices", "passIndices")), value = 0, minValue = 0)
         self.newInput(VectorizedSocket("Boolean", "useMaskLayerList",
             ("Mask Layer", "masksLayer"), ("Masks Layer", "masksLayer")), value = False)
 
         self.newOutput(VectorizedSocket("GPLayer",
-            ["useLayerList", "useNameList", "useBlendModeList", "useOpacityList", "usePassIndexList", "useMaskLayerList"],
+            ["useLayerList", "useNameList", "useBlendModeList", "useOpacityList", "useTintColorList",
+            "useTintFactorList", "useLineChangeList", "usePassIndexList", "useMaskLayerList"],
             ("Layer", "outLayer"), ("Layers", "outLayers")))
 
         for socket in self.inputs[1:]:
@@ -42,44 +52,59 @@ class SetGPLayerAttributesNode(bpy.types.Node, AnimationNode):
         isName = s[1].isUsed
         isBlendMode = s[2].isUsed
         isOpacity = s[3].isUsed
-        isPassIndex = s[4].isUsed
-        isMaskLayer = s[5].isUsed
-        if any([self.useLayerList, self.useNameList, self.useBlendModeList, self.useOpacityList, 
-                self.usePassIndexList, self.useMaskLayerList]):
-            if any([isName, isBlendMode, isOpacity, isPassIndex, isMaskLayer]):
-                if isName:      yield "_layerNames = VirtualPyList.create(layerNames, 'AN-Layer')"
-                if isBlendMode: yield "_blendModes = VirtualPyList.create(blendModes, 'REGULAR')"
-                if isOpacity:   yield "_opacities = VirtualDoubleList.create(opacities, 1)"
-                if isPassIndex: yield "_passIndices = VirtualLongList.create(passIndices, 0)"
-                if isMaskLayer: yield "_masksLayer = VirtualBooleanList.create(masksLayer, False)"
-                    
-                yield                 "_layers = VirtualPyList.create(layers, GPLayer())"
-                yield                 "amount = VirtualPyList.getMaxRealLength(_layers"
-                if isName:      yield "         , _layerNames"
-                if isBlendMode: yield "         , _blendModes"
-                if isOpacity:   yield "         , _opacities"
-                if isPassIndex: yield "         , _passIndices"
-                if isMaskLayer: yield "         , _masksLayer"
-                yield                 "         )"
+        isTintColor = s[4].isUsed
+        isTintFactor = s[5].isUsed
+        isLineChange = s[6].isUsed
+        isPassIndex = s[7].isUsed
+        isMaskLayer = s[8].isUsed
+        if any([self.useLayerList, self.useNameList, self.useBlendModeList, self.useOpacityList, self.useTintColorList,
+                self.useTintFactorList, self.useLineChangeList, self.usePassIndexList, self.useMaskLayerList]):
+            if any([isName, isBlendMode, isOpacity, isTintColor, isTintFactor, isLineChange, isPassIndex, isMaskLayer]):
+                if isName:       yield "_layerNames = VirtualPyList.create(layerNames, 'AN-Layer')"
+                if isBlendMode:  yield "_blendModes = VirtualPyList.create(blendModes, 'REGULAR')"
+                if isOpacity:    yield "_opacities = VirtualDoubleList.create(opacities, 1)"
+                if isTintColor:  yield "_tintColors = VirtualColorList.create(tintColors, Color((0, 0, 0, 0)))"
+                if isTintFactor: yield "_tintFactors = VirtualDoubleList.create(tintFactors, 0)"
+                if isLineChange: yield "_lineChanges = VirtualDoubleList.create(lineChanges, 0)"
+                if isPassIndex:  yield "_passIndices = VirtualLongList.create(passIndices, 0)"
+                if isMaskLayer:  yield "_masksLayer = VirtualBooleanList.create(masksLayer, False)"
 
-                yield                 "outLayers = []"
-                yield                 "for i in range(amount):"
-                yield                 "    layerNew = _layers[i].copy()"
-                if isName:      yield "    layerNew.layerName = _layerNames[i]"
-                if isBlendMode: yield "    self.setBlendMode(layerNew, _blendModes[i])"
-                if isOpacity:   yield "    layerNew.opacity = _opacities[i]"
-                if isPassIndex: yield "    layerNew.passIndex = _passIndices[i]"
-                if isMaskLayer: yield "    layerNew.maskLayer = _masksLayer[i]"
-                yield                 "    outLayers.append(layerNew)"
+                yield                  "_layers = VirtualPyList.create(layers, GPLayer())"
+                yield                  "amount = VirtualPyList.getMaxRealLength(_layers"
+                if isName:       yield "         , _layerNames"
+                if isBlendMode:  yield "         , _blendModes"
+                if isOpacity:    yield "         , _opacities"
+                if isTintColor:  yield "         , _tintColors"
+                if isTintFactor: yield "         , _tintFactors"
+                if isLineChange: yield "         , _lineChanges"
+                if isPassIndex:  yield "         , _passIndices"
+                if isMaskLayer:  yield "         , _masksLayer"
+                yield                  "         )"
+
+                yield                  "outLayers = []"
+                yield                  "for i in range(amount):"
+                yield                  "    layerNew = _layers[i].copy()"
+                if isName:       yield "    layerNew.layerName = _layerNames[i]"
+                if isBlendMode:  yield "    self.setBlendMode(layerNew, _blendModes[i])"
+                if isOpacity:    yield "    layerNew.opacity = _opacities[i]"
+                if isTintColor:  yield "    layerNew.tintColor = _tintColors[i]"
+                if isTintFactor: yield "    layerNew.tintFactor = _tintFactors[i]"
+                if isLineChange: yield "    layerNew.lineChange = _lineChanges[i]"
+                if isPassIndex:  yield "    layerNew.passIndex = _passIndices[i]"
+                if isMaskLayer:  yield "    layerNew.maskLayer = _masksLayer[i]"
+                yield                  "    outLayers.append(layerNew)"
             else:
-                yield                 "outLayers = layers"
+                yield                  "outLayers = layers"
         else:
-            yield                 "outLayer = layers"
-            if isName:      yield "outLayer.layerName = layerNames"
-            if isBlendMode: yield "self.setBlendMode(outLayer, blendModes)"
-            if isOpacity:   yield "outLayer.opacity = opacities"
-            if isPassIndex: yield "outLayer.passIndex = passIndices"
-            if isMaskLayer: yield "outLayer.maskLayer = masksLayer"
+            yield                  "outLayer = layers"
+            if isName:       yield "outLayer.layerName = layerNames"
+            if isBlendMode:  yield "self.setBlendMode(outLayer, blendModes)"
+            if isOpacity:    yield "outLayer.opacity = opacities"
+            if isTintColor:  yield "outLayer.tintColor = tintColors"
+            if isTintFactor: yield "outLayer.tintFactor = tintFactors"
+            if isLineChange: yield "outLayer.lineChange = lineChanges"
+            if isPassIndex:  yield "outLayer.passIndex = passIndices"
+            if isMaskLayer:  yield "outLayer.maskLayer = masksLayer"
 
     def setBlendMode(self, layer, blendMode):
         if blendMode not in ['REGULAR', 'OVERLAY', 'ADD', 'SUBTRACT', 'MULTIPLY', 'DIVIDE']:


### PR DESCRIPTION
I have added the _Tint Color, Factor_ and _Stroke Thickness_ attributes to GP Layer object. These attributes allow adding variation in duplicated layers (multiple layers). For example, Tint Color (based on the Factor) allows adding variation in the color for multiple layers which have only one material. The _Stroke Thickness_ allows changing the thickness of the strokes of a layer.
![Screenshot from 2020-02-14 01-51-14](https://user-images.githubusercontent.com/30294746/74479232-d01fce00-4ed4-11ea-82a2-25f347f3e219.png)

Examples,
![Screenshot from 2020-02-14 01-48-59](https://user-images.githubusercontent.com/30294746/74479265-dca42680-4ed4-11ea-8ea8-c03ee5671e0e.png)

![Screenshot from 2020-02-14 02-27-26](https://user-images.githubusercontent.com/30294746/74479283-e3cb3480-4ed4-11ea-9b3c-81437a594fbd.png)
