### PR TITLE
Decompose Text node.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Added Replicate GP Layer node.
 - Added Offset GP Layer Frames node.
 - Added Set Edge Crease node.
+- Added Decompose Text node.
 
 ### Fixed
 

--- a/animation_nodes/data_structures/virtual_list/__virtual_clist_implementation.src
+++ b/animation_nodes/data_structures/virtual_list/__virtual_clist_implementation.src
@@ -19,13 +19,6 @@ cdef class VirtualLISTNAME(VirtualList):
     def fromElement(cls, element):
         return VirtualLISTNAME_Element(element)
 
-    @classmethod
-    def createMultiple(cls, *elements):
-        cdef list virtualLists = []
-        for src, default in elements:
-            virtualLists.append(VirtualLISTNAME.fromListOrElement(src, default))
-        return virtualLists
-
     def materialize(self, Py_ssize_t length, bint canUseOriginal = False):
         cdef LISTNAME newList = LISTNAME(length = length)
         cdef Py_ssize_t i

--- a/animation_nodes/data_structures/virtual_list/virtual_list.pyx
+++ b/animation_nodes/data_structures/virtual_list/virtual_list.pyx
@@ -4,6 +4,13 @@ cdef class VirtualList:
         return cls.fromListOrElement(source, default)
 
     @classmethod
+    def createMultiple(cls, *elements):
+        cdef list virtualLists = []
+        for src, default in elements:
+            virtualLists.append(cls.fromListOrElement(src, default))
+        return virtualLists
+
+    @classmethod
     def getMaxRealLength(cls, *args):
         return max(obj.getRealLength() for obj in args)
 

--- a/animation_nodes/nodes/text/decompose_text.py
+++ b/animation_nodes/nodes/text/decompose_text.py
@@ -1,0 +1,107 @@
+import bpy
+import blf
+from bpy.props import *
+from mathutils import Matrix
+from string import whitespace
+from functools import lru_cache
+from ... events import propertyChanged
+from ... data_structures import Matrix4x4List
+from ... base_types import AnimationNode, VectorizedSocket
+
+class DecomposeTextNode(bpy.types.Node, AnimationNode):
+    bl_idname = "an_DecomposeTextNode"
+    bl_label = "Decompose Text"
+    errorHandlingType = "EXCEPTION"
+
+    includeWhiteSpaces : BoolProperty(name = "Include White Spaces", default = True,
+        update = propertyChanged)
+
+    def create(self):
+        self.newInput("Text", "Text", "text")
+        self.newInput("Font", "Font", "font")
+        self.newInput("Float", "Character Spacing", "charSpacing", value = 1, hide = True)
+        self.newInput("Float", "Word Spacing", "wordSpacing", value = 1, hide = True)
+        self.newInput("Float", "Line Spacing", "lineSpacing", value = 1, hide = True)
+        self.newInput("Text", "Alignment", "align", value = "LEFT", hide = True)
+
+        self.newOutput("Matrix List", "Transforms", "transforms")
+        self.newOutput("Text List", "Characters", "characters")
+        self.newOutput("Integer", "Length", "length")
+
+    def drawAdvanced(self, layout):
+        layout.prop(self, "includeWhiteSpaces")
+
+    def execute(self, text, font, charSpacing, wordSpacing, lineSpacing, align):
+        self.validateAlignment(align)
+        fontID = self.getFontID(font)
+        fontRatio = self.getFontRatio(font, fontID)
+
+        return self.getCharTransforms(text, fontID, fontRatio, charSpacing, wordSpacing, lineSpacing, align)
+
+    def getCharTransforms(self, text, fontID, fontRatio, charSpacing, wordSpacing, lineSpacing, align):
+        allChars = []
+        allTransforms = Matrix4x4List()
+        for i, line in enumerate(text.splitlines()):
+            chars = []
+            transforms = []
+            comulativeWidth = 0
+            for char in line:
+                if self.includeWhiteSpaces or char not in whitespace:
+                    transforms.append(Matrix.Translation((comulativeWidth, -i * lineSpacing, 0)))
+                    chars.append(char)
+
+                comulativeWidth += self.getCharWidth(fontID, char, fontRatio, charSpacing, wordSpacing)
+
+            transforms = Matrix4x4List.fromValues(transforms)
+
+            if align == "CENTER":
+                offset = (-comulativeWidth + charSpacing / 2 - 0.5) / 2
+                transforms.transform(Matrix.Translation((offset, 0, 0)))
+            elif align == "RIGHT":
+                offset = -comulativeWidth + charSpacing / 2 - 0.5
+                transforms.transform(Matrix.Translation((offset, 0, 0)))
+
+            allChars += chars
+            allTransforms.extend(transforms)
+
+        return allTransforms, allChars, len(allChars)
+
+    def getCharWidth(self, fontID, char, fontRatio, charSpacing, wordSpacing):
+        width = blf.dimensions(fontID, char)[0] * fontRatio
+        if char == " ":
+            width *= wordSpacing
+        return width + charSpacing / 2 - 0.5
+
+    @lru_cache()
+    def getFontRatio(self, font, fontID):
+        data = bpy.data.curves.new("an_helper_font_curve", type = "FONT")
+        textObject = bpy.data.objects.new("an_helper_text_object", data)
+
+        referenceChar = "W"
+
+        data.font = font
+        data.body = referenceChar
+        data.body_format[0].use_underline = True
+
+        actualWidth = textObject.dimensions[0]
+        blfWidth = blf.dimensions(fontID, referenceChar)[0]
+
+        bpy.data.curves.remove(data)
+
+        return actualWidth / blfWidth
+
+    def getFontID(self, font):
+        if font is None or font.filepath == "<builtin>":
+            self.raiseErrorMessage("BFont is not supported!")
+
+        fontID = blf.load(font.filepath)
+
+        if fontID == -1:
+            self.raiseErrorMessage("Can't load font!")
+
+        blf.size(fontID, 50, 72)
+        return fontID
+
+    def validateAlignment(self, align):
+        if align not in ("LEFT", "RIGHT", "CENTER"):
+            self.raiseErrorMessage("Invalid alignment. Possible values are 'LEFT', 'CENTER', and 'RIGHT'.")


### PR DESCRIPTION
# Description

The *Decompose Text* node provides a new workflow to work with texts in Animation Nodes.

Motion graphics typically requires texts to move and deform in a per character/word basis. Previously, to achieve this, one would create the text, invoke the *Separate Text* operator, use the *Initial Transforms ID Key* as a base transformations, and finally offset those transforms as needed. This workflow is not ideal as it requires a lot of manual intervention. Moreover, it is not really procedural and does not fit the general workflow of Animation Nodes.

The *Decompose Text* node provides information to the user so as to allow a completely procedural workflow. In particular, the node decomposes the input text into characters or words and provides the transformations necessary to position those characters or words in space. The node also allows the user to set a multitude of options including character spacing, word spacing, line spacing, text alignment, text sizing, and more.

A base node tree for this workflow would be as follows:

![Base Node Tree](https://user-images.githubusercontent.com/25300994/74645097-fc12ac00-517f-11ea-8ec9-c3d908106f2a.png)

An *Object Instancer* node to create the text objects, a *Text Object Output* node to set the text attributes, and an *Object Matrix Output* node to position the texts in space. Each of the aforementioned nodes takes their inputs from the *Decompose Text* node and possibly from its inputs.

The transforms can be easily manipulated using standard Animation Nodes workflows, such as using falloffs:

![Falloff Example](https://user-images.githubusercontent.com/25300994/74645993-a63f0380-5181-11ea-8791-5a6bbc63e2f5.gif)

The node itself allows manipulations that were even impossible to create using the older workflow. And it provides flexibility that Blender texts doesn't even allow. For instance, per-character sizing based on a drifting sine wave:

![Sizing Example](https://user-images.githubusercontent.com/25300994/74647285-13ec2f00-5184-11ea-9ec9-f9527fe580e8.gif)

This is Animation Nodes, so the possibilities are endless here.

# Implementation

The implementation is a bit tricky because information about fonts is not readily available or exposed by Blender. Essentially, we utilize the `blf` module to get the widths of glyphs and compute the transforms using simple cumulative sums. However, we want widths to exactly match Blender's default text widths, which depends on `VChar.width`, which we don't have. So, we assign an arbitrary size to the `blf` font and compute the ratio between the computed widths and the actual widths using some helper text objects. Notice that underlines are activated because they take the whole width of the glyphs. This process is costly (tens of miliseconds), but the result is cached per font, so I don't really consider this a big issue. The only limitation of the implementation, however, is that BFont is not supported, because it is embedded on the Blender binary and we don't have access to it.