### PR TITLE
Fixed the Triangulate BMesh node.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed crash upon updating the Separate Text node when main collection is hidden.
 - Fixed the New Text Block operator in the script node.
 - Fixed enum callbacks by caching them.
+- Fixed the Triangulate BMesh node.
 
 ### Changed
 

--- a/animation_nodes/nodes/geometry/bmesh_triangulate.py
+++ b/animation_nodes/nodes/geometry/bmesh_triangulate.py
@@ -3,18 +3,30 @@ from bpy.props import *
 from ... events import propertyChanged
 from ... base_types import AnimationNode
 
+quadMethodItems = [
+    ("BEAUTY", "Beauty", "NONE", 0),
+    ("FIXED", "Fixed", "NONE", 1),
+    ("ALTERNATE", "Alternate", "NONE", 2),
+    ("SHORT_EDGE", "Short Edge", "NONE", 3)
+]
+
+ngonMethodItems = [
+    ("BEAUTY", "Beauty", "NONE", 0),
+    ("EAR_CLIP", "Ear Clip", "NONE", 1),
+]
+
 class BMeshTriangulateNode(bpy.types.Node, AnimationNode):
     bl_idname = "an_BMeshTriangulateNode"
     bl_label = "Triangulate BMesh"
     bl_width_default = 160
 
-    quad: IntProperty(name = "Quad Method", max = 3, min = 0,
-        description = "Select a quad triangulation method",
-        update = propertyChanged)
+    quad: EnumProperty(name = "Quad Method", default = "BEAUTY",
+          description = "Select a quad triangulation method",
+          items = quadMethodItems, update = propertyChanged)
 
-    ngon: IntProperty(name = "Ngon Method", max = 1, min = 0,
-        description = "Select a ngon triangulation method",
-        update = propertyChanged)
+    ngon: EnumProperty(name = "Ngon Method", default = "BEAUTY",
+          description = "Select a ngon triangulation method",
+          items = ngonMethodItems, update = propertyChanged)
 
     def create(self):
         self.newInput("BMesh", "BMesh", "bm", dataIsModified = True)


### PR DESCRIPTION
I have fixed the _Triangulate BMesh_ node. Due to changes in the [Blender API](https://docs.blender.org/api/current/bmesh.ops.html#bmesh.ops.triangulate), node showed an error which is now fixed: 
![Screenshot from 2020-03-14 22-39-17](https://user-images.githubusercontent.com/30294746/76686877-f99f5700-6644-11ea-9855-dbb60f705be4.png)
