### PR TITLE
Fix the None material issue of the Material Output node and updated Add menu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added input range to Remap Falloff node.
 - Added Bmesh Invert Normals node.
 - Added Object Material Input node.
+- Added Vector Noise node to the node menu.
 
 ### Fixed
 
@@ -23,6 +24,7 @@
 - Fixed enum callbacks by caching them.
 - Fixed the Triangulate BMesh node.
 - Fixed smooth sound spectrum evaluation.
+- Fixed the None material issue of the Material Output node.
 
 ### Changed
 

--- a/animation_nodes/nodes/material/object_material_output.py
+++ b/animation_nodes/nodes/material/object_material_output.py
@@ -35,6 +35,7 @@ class ObjectMaterialOutputNode(bpy.types.Node, AnimationNode):
         objectMaterials = object.data.materials
         if not self.appendMaterials: objectMaterials.clear()
 
+        if material is None: return object
         self.appendMaterial(objectMaterials, material)
         return object
 
@@ -45,6 +46,7 @@ class ObjectMaterialOutputNode(bpy.types.Node, AnimationNode):
         if not self.appendMaterials: objectMaterials.clear()
 
         for material in materials:
+            if material is None: continue
             self.appendMaterial(objectMaterials, material)
         return object
 

--- a/animation_nodes/ui/node_menu.py
+++ b/animation_nodes/ui/node_menu.py
@@ -105,6 +105,7 @@ class VectorMenu(bpy.types.Menu):
         layout.separator()
         insertNode(layout, "an_RandomVectorNode", "Random")
         insertNode(layout, "an_VectorWiggleNode", "Wiggle")
+        insertNode(layout, "an_VectorNoiseNode", "Noise")
         insertNode(layout, "an_MixDataNode", "Mix", {"dataType" : repr("Vector")})
         layout.separator()
         insertNode(layout, "an_VectorDistanceNode", "Distance")


### PR DESCRIPTION
I have fixed the _None_ material issue of the Material Output node,
![Screenshot from 2020-04-10 23-18-13](https://user-images.githubusercontent.com/30294746/79011413-9cce8800-7b81-11ea-910f-8c851e27eca0.png)

Added the _Vector Noise_ node in the _Add_ menu under the _Vector_ category.
