### PR TITLE
Added Use Spline Radius option in the Spline Falloff node.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added Bmesh Invert Normals node.
 - Added Object Material Input node.
 - Added Vector Noise node to the node menu.
+- Added *Use Spline Radius* option in *Spline Falloff* node.
 
 ### Fixed
 

--- a/animation_nodes/nodes/falloff/spline_falloff.pyx
+++ b/animation_nodes/nodes/falloff/spline_falloff.pyx
@@ -35,11 +35,12 @@ class SplineFalloffNode(bpy.types.Node, AnimationNode):
             ("Spline", "spline", socketProps),
             ("Splines", "splines", socketProps)))
 
+        self.newInput("Boolean", "Use Radius for Distance", "useSplineRadiusForDistance", value = False)
         self.newInput("Float", "Distance", "distance", value = 0)
+        self.newInput("Boolean", "Use Radius for Width", "useSplineRadiusForWidth", value = False)
         self.newInput("Float", "Width", "width", value = 1, minValue = 0)
         self.newInput("Interpolation", "Interpolation", "interpolation",
             defaultDrawType = "PROPERTY_ONLY")
-        self.newInput("Boolean", "Use Spline Radius", "useSplineRadius", value = False)
 
         self.newOutput("Falloff", "Falloff", "falloff")
 
@@ -56,15 +57,15 @@ class SplineFalloffNode(bpy.types.Node, AnimationNode):
         else:
             return "execute_Single"
 
-    def execute_Single(self, spline, distance, width, interpolation, useSplineRadius):
-        falloff = self.falloffFromSpline(spline, distance, width, useSplineRadius)
+    def execute_Single(self, spline, useSplineRadiusForDistance, distance, useSplineRadiusForWidth, width, interpolation):
+        falloff = self.falloffFromSpline(spline, useSplineRadiusForDistance, distance, useSplineRadiusForWidth, width)
         return InterpolateFalloff(falloff, interpolation)
 
-    def execute_List(self, splines, distance, width, interpolation, useSplineRadius):
+    def execute_List(self, splines, useSplineRadiusForDistance, distance, useSplineRadiusForWidth, width, interpolation):
         falloffs = []
         for spline in splines:
             if spline.isEvaluable():
-                falloffs.append(self.falloffFromSpline(spline, distance, width, useSplineRadius))
+                falloffs.append(self.falloffFromSpline(spline, useSplineRadiusForDistance, distance, useSplineRadiusForWidth, width))
 
         if self.mixListType == "ADD":
             interpolatedFalloffs = [InterpolateFalloff(f, interpolation) for f in falloffs]
@@ -73,33 +74,34 @@ class SplineFalloffNode(bpy.types.Node, AnimationNode):
             falloff = MixFalloffs(falloffs, "MAX", default = 0)
             return InterpolateFalloff(falloff, interpolation)
 
-    def falloffFromSpline(self, spline, distance, width, useSplineRadius):
+    def falloffFromSpline(self, spline, useSplineRadiusForDistance, distance, useSplineRadiusForWidth, width):
         if not spline.isEvaluable():
             return ConstantFalloff(0)
 
         if spline.type == "POLY":
             falloffSpline = spline
         else:
-            if useSplineRadius:
+            if useSplineRadiusForDistance or useSplineRadiusForWidth:
                 falloffSpline = PolySpline(spline.getDistributedPoints(self.resolution * (len(spline.points) - 1)),
                                            spline.getDistributedRadii(self.resolution * (len(spline.points) - 1)))
             else:
                 falloffSpline = PolySpline(spline.getDistributedPoints(self.resolution * (len(spline.points) - 1)))
             falloffSpline.cyclic = spline.cyclic
 
-        return SplineFalloff(falloffSpline, distance, width, useSplineRadius)
+        return SplineFalloff(falloffSpline, useSplineRadiusForDistance, distance, useSplineRadiusForWidth, width)
 
 
 cdef class SplineFalloff(BaseFalloff):
     cdef Spline spline
     cdef float distance, width
-    cdef bint useSplineRadius
+    cdef bint useSplineRadiusForDistance, useSplineRadiusForWidth
 
-    def __cinit__(self, Spline spline, float distance, float width, bint useSplineRadius):
+    def __cinit__(self, Spline spline, bint useSplineRadiusForDistance, float distance, bint useSplineRadiusForWidth, float width):
         self.spline = spline
+        self.useSplineRadiusForDistance = useSplineRadiusForDistance
         self.distance = distance
-        self.width = max(width, 0.000001)
-        self.useSplineRadius = useSplineRadius
+        self.useSplineRadiusForWidth = useSplineRadiusForWidth
+        self.width = width
         self.clamped = False
         self.dataType = "LOCATION"
 
@@ -108,12 +110,18 @@ cdef class SplineFalloff(BaseFalloff):
         cdef float parameter = self.spline.project_LowLevel(<Vector3*>point)
         self.spline.evaluatePoint_LowLevel(parameter, &closestPoint)
         cdef float distance = distanceVec3(<Vector3*>point, &closestPoint)
-        cdef float radius = 0
-        if self.useSplineRadius: radius = self.spline.evaluateRadius(parameter)
+        cdef float _distance = self.distance
+        cdef float _width = self.width
+        cdef float radius
+        if self.useSplineRadiusForDistance or self.useSplineRadiusForWidth:
+            radius = self.spline.evaluateRadius_LowLevel(parameter)
+            if self.useSplineRadiusForDistance: _distance *= radius
+            if self.useSplineRadiusForWidth: _width *= radius
 
-        if distance < self.distance:
+        _width = max(_width, 0.000001)
+        if distance < _distance:
             return 1.0
-        elif distance > self.distance + (radius + self.width):
+        elif distance > _distance + _width:
             return 0.0
         else:
-            return 1.0 - (distance - self.distance) / (radius + self.width)
+            return 1.0 - (distance - _distance) / _width


### PR DESCRIPTION
I have added the _Use Spline Radius_ option in the _Spline Falloff_ node which allow to set falloff width based on the spline radius (https://github.com/JacquesLucke/animation_nodes/issues/1394).

![Screenshot from 2020-04-17 01-05-13](https://user-images.githubusercontent.com/30294746/79499711-00a4f500-8049-11ea-81a6-9bfa851bf9b1.png)

Example:
![Screenshot from 2020-04-17 01-04-44](https://user-images.githubusercontent.com/30294746/79499735-0ac6f380-8049-11ea-8bab-141447dfcec7.png)

![untitled3](https://user-images.githubusercontent.com/30294746/79499757-13b7c500-8049-11ea-90ea-969162b43e3a.png)
