### PR TITLE
Fix the output of Set GP Stroke Attributes node for hardness-list input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Fixed missing UV and vertex colors in the Transform Mesh node.
 - Fixed bad splines during rendering and baking.
 - Fixed the spiral method in the Distribute Matrices node for negative amounts.
+- Fixed the output of Set GP Stroke Attributes node for hardness-list input.
 
 ### Changed
 

--- a/animation_nodes/nodes/gpencil/set_gp_stroke_attributes.py
+++ b/animation_nodes/nodes/gpencil/set_gp_stroke_attributes.py
@@ -36,7 +36,7 @@ class SetGPStrokeAttributesNode(bpy.types.Node, AnimationNode):
             ("Display Mode", "displayModes"), ("Display Modes", "displayModes")), value = '3DSPACE', hide = True)
 
         self.newOutput(VectorizedSocket("GPStroke",
-            ["useStrokeList", "useLineWidthList", "useCyclicList",
+            ["useStrokeList", "useLineWidthList", "useHardnessList", "useCyclicList",
             "useStartCapModeList", "useEndCapModeList", "useMaterialIndexList", "useDisplayModeList"],
             ("Stroke", "outStroke"), ("Strokes", "outStrokes")))
 


### PR DESCRIPTION
I have fixed the output of _Set GP Stroke Attributes_ node for hardness-list input. 