### PR TITLE
Add Edges mode and Matrices output to Mesh Points Scatter node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@
 - Added *Calculate Loose Edges* option in *Mesh Object Output* node.
 - Added XoShiRo256 random number generators.
 - Added mesh *Triangulation* methods and *Triangulate Mesh* node.
-- Added Mesh Points Scatter node.
+- Added *Mesh Points Scatter* node.
+- Added matrices output in *Mesh Points Scatter* node.
+- Added edges mode in *Mesh Points Scatter* node.
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Added default values for Script subprogram inputs.
 - Added subtract method to the *Mix Falloff* node.
 - Added order weight option for Viewport Input node.
+- Added matrices output in *Mesh Points Scatter* node.
+- Added edges mode in *Mesh Points Scatter* node.
 
 ### Fixed
 
@@ -37,8 +39,6 @@
 - Added mesh *Triangulation* methods and *Triangulate Mesh* node.
 - Added Mesh Points Scatter node.
 - Added support for 2D vectors in 3D viewer node.
-- Added matrices output in *Mesh Points Scatter* node.
-- Added edges mode in *Mesh Points Scatter* node.
 
 ### Fixed
 

--- a/animation_nodes/algorithms/mesh/points_scatter.pyx
+++ b/animation_nodes/algorithms/mesh/points_scatter.pyx
@@ -19,6 +19,7 @@ from ... math cimport (
     Matrix4,
     crossVec3,
     distanceVec3,
+    createMatrix,
     normalizeVec3_InPlace,
 )
 
@@ -203,10 +204,3 @@ cdef Matrix4x4List sampleRandomPointsOnEdges(Vector3DList vertices, EdgeIndicesL
             index += 1
 
     return matrices
-
-cdef inline void createMatrix(Matrix4 *m, Vector3 *center, Vector3 *tangent,
-                              Vector3 *bitangent, Vector3 *normal):
-    m.a11, m.a12, m.a13, m.a14 = tangent.x, bitangent.x, normal.x, center.x
-    m.a21, m.a22, m.a23, m.a24 = tangent.y, bitangent.y, normal.y, center.y
-    m.a31, m.a32, m.a33, m.a34 = tangent.z, bitangent.z, normal.z, center.z
-    m.a41, m.a42, m.a43, m.a44 = 0, 0, 0, 1

--- a/animation_nodes/algorithms/mesh/points_scatter.pyx
+++ b/animation_nodes/algorithms/mesh/points_scatter.pyx
@@ -19,8 +19,8 @@ from ... math cimport (
     Matrix4,
     crossVec3,
     distanceVec3,
-    createMatrix,
     normalizeVec3_InPlace,
+    matrixFromNormalizedAxisData,
 )
 
 def scatterPointsOnPolygons(Vector3DList vertices, PolygonIndicesList polygons, Vector3DList polyNormals,
@@ -136,7 +136,7 @@ cdef Matrix4x4List sampleRandomPointsOnPolygons(Vector3DList vertices, PolygonIn
             v.y = p1 * v1.y + p2 * v2.y + p3 * v3.y
             v.z = p1 * v1.z + p2 * v2.z + p3 * v3.z
 
-            createMatrix(matrices.data + index, &v, &bitangent, &tangent, &normal)
+            matrixFromNormalizedAxisData(matrices.data + index, &v, &bitangent, &tangent, &normal)
             index += 1
 
     return matrices
@@ -200,7 +200,7 @@ cdef Matrix4x4List sampleRandomPointsOnEdges(Vector3DList vertices, EdgeIndicesL
             v.y = p1 * v1[0].y + p2 * v2[0].y
             v.z = p1 * v1[0].z + p2 * v2[0].z
 
-            createMatrix(matrices.data + index, &v, &bitangent, &tangent, &normal)
+            matrixFromNormalizedAxisData(matrices.data + index, &v, &bitangent, &tangent, &normal)
             index += 1
 
     return matrices

--- a/animation_nodes/algorithms/mesh/points_scatter.pyx
+++ b/animation_nodes/algorithms/mesh/points_scatter.pyx
@@ -1,7 +1,6 @@
 import cython
 from libc.math cimport sqrt, ceil
 from ... algorithms.random_number_generators cimport XoShiRo256Plus, XoShiRo256StarStar
-from ... algorithms.rotations.rotation_and_direction cimport directionToMatrix_LowLevel
 from ... data_structures cimport (
     LongList,
     FloatList,
@@ -19,9 +18,7 @@ from ... math cimport (
     subVec3,
     Matrix4,
     crossVec3,
-    toVector3,
     distanceVec3,
-    setMatrixTranslation,
     normalizeVec3_InPlace,
 )
 

--- a/animation_nodes/math/matrix.pxd
+++ b/animation_nodes/math/matrix.pxd
@@ -61,3 +61,6 @@ cdef void invertOrthogonalTransformation(Matrix4* t, Matrix4* m)
 cdef void scaleMatrix3x3Part(Matrix3_or_Matrix4 *m, float s)
 
 cdef float getMatrix3x3PartDeterminant(Matrix3_or_Matrix4 *m)
+
+cdef void createMatrix(Matrix4 *m, Vector3 *center, Vector3 *tangent,
+                       Vector3 *bitangent, Vector3 *normal)

--- a/animation_nodes/math/matrix.pxd
+++ b/animation_nodes/math/matrix.pxd
@@ -62,5 +62,5 @@ cdef void scaleMatrix3x3Part(Matrix3_or_Matrix4 *m, float s)
 
 cdef float getMatrix3x3PartDeterminant(Matrix3_or_Matrix4 *m)
 
-cdef void createMatrix(Matrix4 *m, Vector3 *center, Vector3 *tangent,
-                       Vector3 *bitangent, Vector3 *normal)
+cdef void matrixFromNormalizedAxisData(Matrix4 *m, Vector3 *center, Vector3 *tangent,
+                                       Vector3 *bitangent, Vector3 *normal)

--- a/animation_nodes/math/matrix.pyx
+++ b/animation_nodes/math/matrix.pyx
@@ -316,3 +316,10 @@ cdef float getMatrix3x3PartDeterminant(Matrix3_or_Matrix4 *m):
         m.a12 * m.a21 * m.a33 -
         m.a11 * m.a23 * m.a32
     )
+
+cdef void createMatrix(Matrix4 *m, Vector3 *center, Vector3 *tangent,
+                              Vector3 *bitangent, Vector3 *normal):
+    m.a11, m.a12, m.a13, m.a14 = tangent.x, bitangent.x, normal.x, center.x
+    m.a21, m.a22, m.a23, m.a24 = tangent.y, bitangent.y, normal.y, center.y
+    m.a31, m.a32, m.a33, m.a34 = tangent.z, bitangent.z, normal.z, center.z
+    m.a41, m.a42, m.a43, m.a44 = 0, 0, 0, 1

--- a/animation_nodes/math/matrix.pyx
+++ b/animation_nodes/math/matrix.pyx
@@ -317,8 +317,8 @@ cdef float getMatrix3x3PartDeterminant(Matrix3_or_Matrix4 *m):
         m.a11 * m.a23 * m.a32
     )
 
-cdef void createMatrix(Matrix4 *m, Vector3 *center, Vector3 *tangent,
-                              Vector3 *bitangent, Vector3 *normal):
+cdef void matrixFromNormalizedAxisData(Matrix4 *m, Vector3 *center, Vector3 *tangent,
+                                       Vector3 *bitangent, Vector3 *normal):
     m.a11, m.a12, m.a13, m.a14 = tangent.x, bitangent.x, normal.x, center.x
     m.a21, m.a22, m.a23, m.a24 = tangent.y, bitangent.y, normal.y, center.y
     m.a31, m.a32, m.a33, m.a34 = tangent.z, bitangent.z, normal.z, center.z

--- a/animation_nodes/nodes/mesh/mesh_points_scatter.py
+++ b/animation_nodes/nodes/mesh/mesh_points_scatter.py
@@ -43,8 +43,8 @@ class MeshPointsScatterNode(bpy.types.Node, AnimationNode):
 
     def draw(self, layout):
         row = layout.row(align = True)
-        layout.prop(self, "mode", text = "")
         row.prop(self, "nodeSeed", text = "Node Seed")
+        layout.prop(self, "mode", text = "")
 
     def drawAdvanced(self, layout):
         layout.prop(self, "methodType", text = "Use Advanced Method for Mesh sampling")

--- a/animation_nodes/nodes/mesh/mesh_points_scatter.py
+++ b/animation_nodes/nodes/mesh/mesh_points_scatter.py
@@ -4,17 +4,25 @@ from bpy.props import *
 from ... utils.math import cantorPair
 from ... events import propertyChanged
 from ... base_types import AnimationNode
-from ... data_structures import Vector3DList, VirtualDoubleList
-from ... algorithms.mesh.points_scatter import randomPointsScatter
+from ... data_structures import Matrix4x4List, VirtualDoubleList
 from ... data_structures.meshes.mesh_data import calculatePolygonNormals
+from ... algorithms.mesh.points_scatter import randomPointsScatter, randomPointsScatterForEdges
 from ... algorithms.mesh.triangulate_mesh import (
     triangulatePolygonsUsingFanSpanMethod,
     triangulatePolygonsUsingEarClipMethod
 )
 
+modeItems = [
+    ("EDGES", "Edges", "Scatter points on edges", "NONE", 0),
+    ("POLYGONS", "Polygons", "Scatter points on polygons", "NONE", 1)
+]
+
 class MeshPointsScatterNode(bpy.types.Node, AnimationNode):
     bl_idname = "an_MeshPointsScatterNode"
     bl_label = "Mesh Points Scatter"
+
+    mode: EnumProperty(name = "Mode", default = "POLYGONS",
+        items = modeItems, update = AnimationNode.refresh)
 
     methodType: BoolProperty(name = "Use Advanced Method for Mesh sampling", default = False,
                              update = propertyChanged)
@@ -35,6 +43,7 @@ class MeshPointsScatterNode(bpy.types.Node, AnimationNode):
 
     def draw(self, layout):
         row = layout.row(align = True)
+        layout.prop(self, "mode", text = "")
         row.prop(self, "nodeSeed", text = "Node Seed")
 
     def drawAdvanced(self, layout):
@@ -49,19 +58,25 @@ class MeshPointsScatterNode(bpy.types.Node, AnimationNode):
     def execute_RandomPointsScatter(self, mesh, seed, amount, weights):
         vertices = mesh.vertices
         polygons = mesh.polygons
+        edges = mesh.edges
 
-        if len(vertices) == 0 or len(polygons) == 0 or amount == 0:
-            return Vector3DList()
+        if len(vertices) == 0 or amount == 0:
+            return Matrix4x4List()
 
-        if polygons.polyLengths.getMaxValue() > 3:
-            if self.methodType:
-                polygons = triangulatePolygonsUsingEarClipMethod(vertices, polygons)
-            else:
-                polygons = triangulatePolygonsUsingFanSpanMethod(polygons)
-        polyNormals = calculatePolygonNormals(vertices, polygons)
         weights = VirtualDoubleList.create(weights, 1)
         seed = cantorPair(int(max(seed, 0)), self.nodeSeed)
-        return randomPointsScatter(vertices, polygons, polyNormals, weights, seed, max(amount, 0))
+        if self.mode == "POLYGONS":
+            if len(polygons) == 0: return Matrix4x4List()
+            if polygons.polyLengths.getMaxValue() > 3:
+                if self.methodType:
+                    polygons = triangulatePolygonsUsingEarClipMethod(vertices, polygons)
+                else:
+                    polygons = triangulatePolygonsUsingFanSpanMethod(polygons)
+            polyNormals = calculatePolygonNormals(vertices, polygons)
+            return randomPointsScatter(vertices, polygons, polyNormals, weights, seed, max(amount, 0))
+        else:
+            if len(edges) == 0: return Matrix4x4List()
+            return randomPointsScatterForEdges(vertices, edges, weights, seed, max(amount, 0))
 
     def duplicate(self, sourceNode):
         self.randomizeNodeSeed()

--- a/animation_nodes/nodes/mesh/mesh_points_scatter.py
+++ b/animation_nodes/nodes/mesh/mesh_points_scatter.py
@@ -44,7 +44,7 @@ class MeshPointsScatterNode(bpy.types.Node, AnimationNode):
         yield "matrices = self.execute_RandomPointsScatter(mesh, seed, amount, weights)"
 
         if "vectors" in required:
-            yield "AN.nodes.matrix.c_utils.extractMatrixTranslations(matrices)"
+            yield "vectors = AN.nodes.matrix.c_utils.extractMatrixTranslations(matrices)"
 
     def execute_RandomPointsScatter(self, mesh, seed, amount, weights):
         vertices = mesh.vertices

--- a/animation_nodes/nodes/mesh/mesh_points_scatter.py
+++ b/animation_nodes/nodes/mesh/mesh_points_scatter.py
@@ -76,7 +76,8 @@ class MeshPointsScatterNode(bpy.types.Node, AnimationNode):
             return randomPointsScatter(vertices, polygons, polyNormals, weights, seed, max(amount, 0))
         else:
             if len(edges) == 0: return Matrix4x4List()
-            return randomPointsScatterForEdges(vertices, edges, weights, seed, max(amount, 0))
+            normals = mesh.getVertexNormals()
+            return randomPointsScatterForEdges(vertices, edges, normals, weights, seed, max(amount, 0))
 
     def duplicate(self, sourceNode):
         self.randomizeNodeSeed()


### PR DESCRIPTION
Hi, I have added the *Edges* mode to *Mesh Points Scatter* node that allows scattering random points on edges of the mesh. It also useful in case of *Line(s)* mesh. I have also added the *Matrices* output for random points and these matrices are aligned with normal of the polygons of mesh.

![Screenshot from 2020-08-10 22-55-12](https://user-images.githubusercontent.com/30294746/89812087-37a19800-db5d-11ea-807c-54b792dbbe15.png)
 
![Screenshot from 2020-08-10 22-54-03](https://user-images.githubusercontent.com/30294746/89812113-3d977900-db5d-11ea-968f-bdc19eba82dd.png)

![Screenshot from 2020-08-10 22-52-57](https://user-images.githubusercontent.com/30294746/89812125-42f4c380-db5d-11ea-886f-19ff2aaa73f1.png)
