### PR TITLE
Add Vertex Color Fill to GP Nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@
 - Added curve dimensions option to the Separate Text node.
 - Added matrices output in *Mesh Points Scatter* node.
 - Added edges mode in *Mesh Points Scatter* node.
-- Added *Vertex Color Fill* in *GP Stroke Info*, *GP Stroke From Points*,
-  and *Set GP Stroke Attributes* nodes.
+- Added *Vertex Color Fill* attribute to GP strokes.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Added XoShiRo256 random number generators.
 - Added mesh *Triangulation* methods and *Triangulate Mesh* node.
 - Added Mesh Points Scatter node.
+- Added *Vertex Color Fill* in *GP Stroke Info*, *GP Stroke From Points*, and *Set GP Stroke Attributes* nodes.
 
 ### Fixed
 

--- a/animation_nodes/data_structures/gpencils/gp_stroke_data.py
+++ b/animation_nodes/data_structures/gpencils/gp_stroke_data.py
@@ -1,6 +1,6 @@
 import textwrap
-from .. lists.base_lists import FloatList, Vector3DList, ColorList
 from ... data_structures.color import Color
+from .. lists.base_lists import FloatList, Vector3DList, ColorList
 
 class GPStroke:
     def __init__(self, vertices = None, strengths = None, pressures = None,

--- a/animation_nodes/data_structures/gpencils/gp_stroke_data.py
+++ b/animation_nodes/data_structures/gpencils/gp_stroke_data.py
@@ -1,11 +1,13 @@
 import textwrap
 from .. lists.base_lists import FloatList, Vector3DList, ColorList
+from ... data_structures.color import Color
 
 class GPStroke:
     def __init__(self, vertices = None, strengths = None, pressures = None,
                  uvRotations = None, vertexColors = None, lineWidth = None,
                  hardness = None, drawCyclic = None, startCapMode = None,
-                 endCapMode = None, materialIndex = None, displayMode = None):
+                 endCapMode = None, vertexColorFill = None, materialIndex = None,
+                 displayMode = None):
 
         if vertices is None: vertices = Vector3DList()
         if strengths is None: strengths = FloatList()
@@ -17,6 +19,7 @@ class GPStroke:
         if drawCyclic is None: drawCyclic = False
         if startCapMode is None: startCapMode = "ROUND"
         if endCapMode is None: endCapMode = "ROUND"
+        if vertexColorFill is None: vertexColorFill = Color((0, 0, 0, 0))
         if materialIndex is None: materialIndex = 0
         if displayMode is None: displayMode = "3DSPACE"
 
@@ -30,6 +33,7 @@ class GPStroke:
         self.drawCyclic = drawCyclic
         self.startCapMode = startCapMode
         self.endCapMode = endCapMode
+        self.vertexColorFill = vertexColorFill
         self.materialIndex = materialIndex
         self.displayMode = displayMode
 
@@ -42,6 +46,7 @@ class GPStroke:
             Cyclic: {self.drawCyclic}
             Start Cap Mode: {self.startCapMode}
             End Cap Mode: {self.endCapMode}
+            Vertex Color Fill: {self.vertexColorFill}
             Material Index: {self.materialIndex}
             Display Mode: {self.displayMode}""")
 
@@ -49,4 +54,4 @@ class GPStroke:
         return GPStroke(self.vertices.copy(), self.strengths.copy(), self.pressures.copy(),
                         self.uvRotations.copy(), self.vertexColors.copy(), self.lineWidth,
                         self.hardness, self.drawCyclic, self.startCapMode, self.endCapMode,
-                        self.materialIndex, self.displayMode)
+                        self.vertexColorFill, self.materialIndex, self.displayMode)

--- a/animation_nodes/nodes/gpencil/gp_object_input.py
+++ b/animation_nodes/nodes/gpencil/gp_object_input.py
@@ -122,4 +122,4 @@ class GPObjectInputNode(bpy.types.Node, AnimationNode):
 
     def getVertexColorFill(self, stroke):
         color = stroke.vertex_color_fill
-        return Color((color[0], color[1], color[2], color[3]))
+        return Color(tuple(color))

--- a/animation_nodes/nodes/gpencil/gp_object_input.py
+++ b/animation_nodes/nodes/gpencil/gp_object_input.py
@@ -117,4 +117,9 @@ class GPObjectInputNode(bpy.types.Node, AnimationNode):
         strokePoints.foreach_get("vertex_color", vertexColors.asNumpyArray())
 
         return GPStroke(vertices, strengths, pressures, uvRotations, vertexColors, stroke.line_width, stroke.hardness,
-                        stroke.draw_cyclic, stroke.start_cap_mode, stroke.end_cap_mode, stroke.material_index, stroke.display_mode)
+                        stroke.draw_cyclic, stroke.start_cap_mode, stroke.end_cap_mode, self.getVertexColorFill(stroke),
+                        stroke.material_index, stroke.display_mode)
+
+    def getVertexColorFill(self, stroke):
+        color = stroke.vertex_color_fill
+        return Color((color[0], color[1], color[2], color[3]))

--- a/animation_nodes/nodes/gpencil/gp_object_output.py
+++ b/animation_nodes/nodes/gpencil/gp_object_output.py
@@ -87,11 +87,12 @@ class GPObjectOutputNode(bpy.types.Node, AnimationNode):
     def setStrokeProperties(self, gpStroke, stroke):
         gpStroke.line_width = stroke.lineWidth
         gpStroke.hardness = stroke.hardness
-        gpStroke.material_index = stroke.materialIndex
-        gpStroke.display_mode = stroke.displayMode
         gpStroke.draw_cyclic = stroke.drawCyclic
         gpStroke.start_cap_mode = stroke.startCapMode
         gpStroke.end_cap_mode = stroke.endCapMode
+        gpStroke.vertex_color_fill = stroke.vertexColorFill
+        gpStroke.material_index = stroke.materialIndex
+        gpStroke.display_mode = stroke.displayMode
 
     def getLayer(self, gpencil, layer):
         layerName = layer.layerName

--- a/animation_nodes/nodes/gpencil/gp_stroke_from_points.py
+++ b/animation_nodes/nodes/gpencil/gp_stroke_from_points.py
@@ -27,12 +27,13 @@ class GPStrokeFromPointsNode(bpy.types.Node, AnimationNode):
         self.newInput("Boolean", "Cyclic", "drawCyclic", value = False, hide = True)
         self.newInput("Text", "Start Cap Mode", "startCapMode", value = 'ROUND', hide = True)
         self.newInput("Text", "End Cap Mode", "endCapMode", value = 'ROUND', hide = True)
+        self.newInput("Color", "Vertex Color Fill", "vertexColorFill", value = (0, 0, 0, 0), hide = True)
         self.newInput("Integer", "Material Index", "materialIndex", value = 0)
         self.newInput("Text", "Display Mode", "displayMode", value = '3DSPACE', hide = True)
         self.newOutput("GPStroke", "Stroke", "stroke")
 
-    def execute(self, vertices, strengths, pressures, uvRotations, vertexColors, lineWidth,
-                hardness, drawCyclic, startCapMode, endCapMode, materialIndex, displayMode):
+    def execute(self, vertices, strengths, pressures, uvRotations, vertexColors, lineWidth, hardness,
+                drawCyclic, startCapMode, endCapMode, vertexColorFill, materialIndex, displayMode):
 
         amount = len(vertices)
         strengths = FloatList.fromValues(VirtualDoubleList.create(strengths, 1).materialize(amount))
@@ -47,5 +48,5 @@ class GPStrokeFromPointsNode(bpy.types.Node, AnimationNode):
         if displayMode not in ['SCREEN', '3DSPACE', '2DSPACE', '2DIMAGE']:
             self.raiseErrorMessage("The Display Mode is invalid. \n\nPossible values for 'Display Mode' are: 'SCREEN', '3DSPACE', '2DSPACE', '2DIMAGE'")
 
-        return GPStroke(vertices, strengths, pressures, uvRotations, vertexColors, lineWidth,
-                        hardness, drawCyclic, startCapMode, endCapMode, materialIndex, displayMode)
+        return GPStroke(vertices, strengths, pressures, uvRotations, vertexColors, lineWidth, hardness,
+                        drawCyclic, startCapMode, endCapMode, vertexColorFill, materialIndex, displayMode)

--- a/animation_nodes/nodes/gpencil/gp_stroke_info.py
+++ b/animation_nodes/nodes/gpencil/gp_stroke_info.py
@@ -19,6 +19,7 @@ class GPStrokeInfoNode(bpy.types.Node, AnimationNode):
         self.newOutput("Boolean", "Cyclic", "drawCyclic", hide = True)
         self.newOutput("Text", "Start Cap Mode", "startCapMode", hide = True)
         self.newOutput("Text", "End Cap Mode", "endCapMode", hide = True)
+        self.newOutput("Color", "Vertex Color Fill", "vertexColorFill")
         self.newOutput("Integer", "Material Index", "materialIndex")
         self.newOutput("Text", "Display Mode", "displayMode", hide = True)
 
@@ -28,4 +29,4 @@ class GPStrokeInfoNode(bpy.types.Node, AnimationNode):
         uvRotations = DoubleList.fromValues(stroke.uvRotations)
         return (stroke.vertices, strengths, pressures, uvRotations, stroke.vertexColors,
                 stroke.lineWidth, stroke.hardness, stroke.drawCyclic, stroke.startCapMode,
-                stroke.endCapMode, stroke.materialIndex, stroke.displayMode)
+                stroke.endCapMode, stroke.vertexColorFill, stroke.materialIndex, stroke.displayMode)

--- a/animation_nodes/nodes/gpencil/set_gp_stroke_attributes.py
+++ b/animation_nodes/nodes/gpencil/set_gp_stroke_attributes.py
@@ -14,6 +14,7 @@ class SetGPStrokeAttributesNode(bpy.types.Node, AnimationNode):
     useCyclicList: VectorizedSocket.newProperty()
     useStartCapModeList: VectorizedSocket.newProperty()
     useEndCapModeList: VectorizedSocket.newProperty()
+    useVertexColorFillList: VectorizedSocket.newProperty()
     useMaterialIndexList: VectorizedSocket.newProperty()
     useDisplayModeList: VectorizedSocket.newProperty()
 
@@ -30,14 +31,16 @@ class SetGPStrokeAttributesNode(bpy.types.Node, AnimationNode):
             ("Start Cap Mode", "startCapModes"), ("Start Cap Modes", "startCapModes")), value = 'ROUND', hide = True)
         self.newInput(VectorizedSocket("Text", "useEndCapModeList",
             ("End Cap Mode", "endCapModes"), ("End Cap Modes", "endCapModes")), value = 'ROUND', hide = True)
+        self.newInput(VectorizedSocket("Color", "useVertexColorFillList",
+            ("Vertex Color Fill", "vertexColorFills", dict(value = (0, 0, 0, 0))), ("Vertex Color Fills", "vertexColorFills")))
         self.newInput(VectorizedSocket("Integer", "useMaterialIndexList",
             ("Material Index", "materialIndices"), ("Material Indices", "materialIndices")), value = 0, minValue = 0)
         self.newInput(VectorizedSocket("Text", "useDisplayModeList",
             ("Display Mode", "displayModes"), ("Display Modes", "displayModes")), value = '3DSPACE', hide = True)
 
         self.newOutput(VectorizedSocket("GPStroke",
-            ["useStrokeList", "useLineWidthList", "useCyclicList",
-            "useStartCapModeList", "useEndCapModeList", "useMaterialIndexList", "useDisplayModeList"],
+            ["useStrokeList", "useLineWidthList", "useHardnessList", "useCyclicList", "useStartCapModeList",
+             "useEndCapModeList", "useVertexColorFillList", "useMaterialIndexList", "useDisplayModeList"],
             ("Stroke", "outStroke"), ("Strokes", "outStrokes")))
 
         for socket in self.inputs[1:]:
@@ -51,54 +54,61 @@ class SetGPStrokeAttributesNode(bpy.types.Node, AnimationNode):
         isCylic = s[3].isUsed
         isStartCapMode = s[4].isUsed
         isEndCapMode = s[5].isUsed
-        isMaterialIndex = s[6].isUsed
-        isDisplayMode = s[7].isUsed
+        isVertexColorFill = s[6].isUsed
+        isMaterialIndex = s[7].isUsed
+        isDisplayMode = s[8].isUsed
 
         if any([self.useStrokeList, self.useLineWidthList, self.useHardnessList, self.useCyclicList,
-                self.useStartCapModeList, self.useEndCapModeList, self.useMaterialIndexList, self.useDisplayModeList]):
-            if any([isLineWidth, isHardness, isCylic, isStartCapMode, isEndCapMode, isMaterialIndex, isDisplayMode]):
-                if isLineWidth:     yield "_lineWidths = VirtualDoubleList.create(lineWidths, 0)"
-                if isHardness:     yield "_hardnesses = VirtualDoubleList.create(hardnesses, 0)"
-                if isCylic:         yield "_cyclics = VirtualBooleanList.create(cyclics, False)"
-                if isStartCapMode:  yield "_startCapModes = VirtualPyList.create(startCapModes, 'ROUND')"
-                if isEndCapMode:    yield "_endCapModes = VirtualPyList.create(endCapModes, 'ROUND')"
-                if isMaterialIndex: yield "_materialIndices = VirtualLongList.create(materialIndices, 0)"
-                if isDisplayMode:   yield "_displayModes = VirtualPyList.create(displayModes, '3DSPACE')"
+                self.useStartCapModeList, self.useEndCapModeList, self.useVertexColorFillList,
+                self.useMaterialIndexList, self.useDisplayModeList]):
+            if any([isLineWidth, isHardness, isCylic, isStartCapMode, isEndCapMode, isVertexColorFill,
+                    isMaterialIndex, isDisplayMode]):
+                if isLineWidth:       yield "_lineWidths = VirtualDoubleList.create(lineWidths, 0)"
+                if isHardness:        yield "_hardnesses = VirtualDoubleList.create(hardnesses, 0)"
+                if isCylic:           yield "_cyclics = VirtualBooleanList.create(cyclics, False)"
+                if isStartCapMode:    yield "_startCapModes = VirtualPyList.create(startCapModes, 'ROUND')"
+                if isEndCapMode:      yield "_endCapModes = VirtualPyList.create(endCapModes, 'ROUND')"
+                if isVertexColorFill: yield "_vertexColorFills = VirtualColorList.create(vertexColorFills, Color((0, 0, 0, 0)))"
+                if isMaterialIndex:   yield "_materialIndices = VirtualLongList.create(materialIndices, 0)"
+                if isDisplayMode:     yield "_displayModes = VirtualPyList.create(displayModes, '3DSPACE')"
 
-                yield                     "_strokes = VirtualPyList.create(strokes, GPStroke())"
-                yield                     "amount = VirtualPyList.getMaxRealLength(_strokes"
-                if isLineWidth:     yield "         , _lineWidths"
-                if isHardness:     yield "         , _hardnesses"
-                if isCylic:         yield "         , _cyclics"
-                if isStartCapMode:  yield "         , _startCapModes"
-                if isEndCapMode:    yield "         , _endCapModes"
-                if isMaterialIndex: yield "         , _materialIndices"
-                if isDisplayMode:   yield "         , _displayModes"
-                yield                     "         )"
+                yield                       "_strokes = VirtualPyList.create(strokes, GPStroke())"
+                yield                       "amount = VirtualPyList.getMaxRealLength(_strokes"
+                if isLineWidth:       yield "         , _lineWidths"
+                if isHardness:        yield "         , _hardnesses"
+                if isCylic:           yield "         , _cyclics"
+                if isStartCapMode:    yield "         , _startCapModes"
+                if isEndCapMode:      yield "         , _endCapModes"
+                if isVertexColorFill: yield "         , _vertexColorFills"
+                if isMaterialIndex:   yield "         , _materialIndices"
+                if isDisplayMode:     yield "         , _displayModes"
+                yield                       "         )"
 
-                yield                     "outStrokes = []"
-                yield                     "for i in range(amount):"
-                yield                     "    strokeNew = _strokes[i].copy()"
-                if isLineWidth:     yield "    strokeNew.lineWidth = _lineWidths[i]"
-                if isHardness:      yield "    strokeNew.hardness = _hardnesses[i]"
-                if isCylic:         yield "    strokeNew.drawCyclic = _cyclics[i]"
-                if isStartCapMode:  yield "    self.setStartCapMode(strokeNew, _startCapModes[i])"
-                if isEndCapMode:    yield "    self.setEndCapMode(strokeNew, _endCapModes[i])"
-                if isMaterialIndex: yield "    strokeNew.materialIndex = _materialIndices[i]"
-                if isDisplayMode:   yield "    self.setDisplayMode(strokeNew, _displayModes[i])"
-                yield                     "    outStrokes.append(strokeNew)"
+                yield                       "outStrokes = []"
+                yield                       "for i in range(amount):"
+                yield                       "    strokeNew = _strokes[i].copy()"
+                if isLineWidth:       yield "    strokeNew.lineWidth = _lineWidths[i]"
+                if isHardness:        yield "    strokeNew.hardness = _hardnesses[i]"
+                if isCylic:           yield "    strokeNew.drawCyclic = _cyclics[i]"
+                if isStartCapMode:    yield "    self.setStartCapMode(strokeNew, _startCapModes[i])"
+                if isEndCapMode:      yield "    self.setEndCapMode(strokeNew, _endCapModes[i])"
+                if isVertexColorFill: yield "    strokeNew.vertexColorFill = _vertexColorFills[i]"
+                if isMaterialIndex:   yield "    strokeNew.materialIndex = _materialIndices[i]"
+                if isDisplayMode:     yield "    self.setDisplayMode(strokeNew, _displayModes[i])"
+                yield                       "    outStrokes.append(strokeNew)"
             else:
-                yield                     "outStrokes = strokes"
+                yield                       "outStrokes = strokes"
 
         else:
-            yield                     "outStroke = strokes"
-            if isLineWidth:     yield "outStroke.lineWidth = lineWidths"
-            if isHardness:      yield "outStroke.hardness = hardnesses"
-            if isCylic:         yield "outStroke.drawCyclic = cyclics"
-            if isStartCapMode:  yield "self.setStartCapMode(outStroke, startCapModes)"
-            if isEndCapMode:    yield "self.setEndCapMode(outStroke, endCapModes)"
-            if isMaterialIndex: yield "outStroke.materialIndex = materialIndices"
-            if isDisplayMode:   yield "self.setDisplayMode(outStroke, displayModes)"
+            yield                       "outStroke = strokes"
+            if isLineWidth:       yield "outStroke.lineWidth = lineWidths"
+            if isHardness:        yield "outStroke.hardness = hardnesses"
+            if isCylic:           yield "outStroke.drawCyclic = cyclics"
+            if isStartCapMode:    yield "self.setStartCapMode(outStroke, startCapModes)"
+            if isEndCapMode:      yield "self.setEndCapMode(outStroke, endCapModes)"
+            if isVertexColorFill: yield "outStroke.vertexColorFill = vertexColorFills"
+            if isMaterialIndex:   yield "outStroke.materialIndex = materialIndices"
+            if isDisplayMode:     yield "self.setDisplayMode(outStroke, displayModes)"
 
     def setStartCapMode(self, stroke, startCapMode):
         if startCapMode not in ['ROUND', 'FLAT']:


### PR DESCRIPTION
I have added *Vertex Color Fill* attribute to *GP Stroke*. This allows to get/set the *Vertex Color* of *Fill*  stroke.

![GP](https://user-images.githubusercontent.com/30294746/90095693-0c7e9a80-dd4f-11ea-98ed-67d8c88aca55.png)
