### PR TITLE
 Add Axis Scale option in Viewer 3D node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added edges mode in *Mesh Points Scatter* node.
 - Added *Vertex Color Fill* attribute to GP strokes.
 - Added *Radial Falloff* node.
+- Added *Axis Scale* option in *Viewer 3D* node.
 
 ### Fixed
 

--- a/animation_nodes/graphics/c_utils.pyx
+++ b/animation_nodes/graphics/c_utils.pyx
@@ -1,7 +1,7 @@
 from .. math cimport Vector3
 from .. data_structures cimport Vector3DList, Matrix4x4List, IntegerList
 
-def getMatricesVBOandIBO(Matrix4x4List matrices, float scale):
+def getMatricesVBOandIBO(Matrix4x4List matrices, float scaleX, float scaleY, float scaleZ):
     cdef Py_ssize_t i
     cdef int length = len(matrices)
     cdef Vector3DList vectors = Vector3DList(length = length * 4)
@@ -11,17 +11,17 @@ def getMatricesVBOandIBO(Matrix4x4List matrices, float scale):
         x, y, z = matrices.data[i].a14, matrices.data[i].a24, matrices.data[i].a34
         vectors.data[i * 4] = Vector3(x, y, z)
         vectors.data[i * 4 + 1] = Vector3(
-            x + matrices.data[i].a11 * scale,
-            y + matrices.data[i].a21 * scale,
-            z + matrices.data[i].a31 * scale)
+            x + matrices.data[i].a11 * scaleX,
+            y + matrices.data[i].a21 * scaleX,
+            z + matrices.data[i].a31 * scaleX)
         vectors.data[i * 4 + 2] = Vector3(
-            x + matrices.data[i].a12 * scale,
-            y + matrices.data[i].a22 * scale,
-            z + matrices.data[i].a32 * scale)
+            x + matrices.data[i].a12 * scaleY,
+            y + matrices.data[i].a22 * scaleY,
+            z + matrices.data[i].a32 * scaleY)
         vectors.data[i * 4 + 3] = Vector3(
-            x + matrices.data[i].a13 * scale,
-            y + matrices.data[i].a23 * scale,
-            z + matrices.data[i].a33 * scale)
+            x + matrices.data[i].a13 * scaleZ,
+            y + matrices.data[i].a23 * scaleZ,
+            z + matrices.data[i].a33 * scaleZ)
         indices.data[i * 6] = i * 4
         indices.data[i * 6 + 1] = i * 4 + 1
         indices.data[i * 6 + 2] = i * 4


### PR DESCRIPTION
I have added `XYZ` options for matrices in *Viewer 3D* node. These options allow to choose the axis for drawing.
![Screenshot from 2020-08-14 21-00-15](https://user-images.githubusercontent.com/30294746/90266125-2d3f1100-de71-11ea-8bf4-00f3d8af7b2b.png)
