### PR TITLE
Align Pi menu for nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Added Interpolation input to *Remap Falloff* node.
 - Added *Decompose Text* node to menu.
 - Added *Repeat List Elements* node.
+- Added *Align Pie* menu for nodes alignment.
 
 ### Fixed
 

--- a/animation_nodes/keymap.py
+++ b/animation_nodes/keymap.py
@@ -22,6 +22,10 @@ def register():
     kmi = km.keymap_items.new("wm.call_menu_pie", type = "E", value = "PRESS")
     kmi.properties.name = "AN_MT_selection_pie"
 
+    # Selection Pie Menu
+    kmi = km.keymap_items.new("wm.call_menu_pie", type = "F", value = "PRESS")
+    kmi.properties.name = "AN_MT_align_pie"
+
     # Floating Node Settings
     km.keymap_items.new("an.floating_node_settings_panel", type = "U", value = "PRESS")
 

--- a/animation_nodes/keymap.py
+++ b/animation_nodes/keymap.py
@@ -22,8 +22,8 @@ def register():
     kmi = km.keymap_items.new("wm.call_menu_pie", type = "E", value = "PRESS")
     kmi.properties.name = "AN_MT_selection_pie"
 
-    # Selection Pie Menu
-    kmi = km.keymap_items.new("wm.call_menu_pie", type = "F", value = "PRESS")
+    # Align Pie Menu
+    kmi = km.keymap_items.new("wm.call_menu_pie", type = "E", value = "PRESS", ctrl = True)
     kmi.properties.name = "AN_MT_align_pie"
 
     # Floating Node Settings

--- a/animation_nodes/operators/node_align.py
+++ b/animation_nodes/operators/node_align.py
@@ -25,8 +25,7 @@ def alignDependent(offset, nodes):
         activeLocation = activeNode.location
         xOffset = activeNode.width / 2
         yOffset = activeNode.height / 2
-        for i, node in enumerate(nodes):
-            if i == 0: continue
+        for node in nodes[1:]:
             if type(node) == list:
                 alignDependent(offset, node)
             else:

--- a/animation_nodes/operators/node_align.py
+++ b/animation_nodes/operators/node_align.py
@@ -1,5 +1,6 @@
 import bpy
 from mathutils import Vector
+from .. preferences import getPieMenuSettings
 from .. tree_info import getDirectlyLinkedSockets
 
 class NodeOperator:
@@ -15,7 +16,7 @@ class AlignDependentNodes(bpy.types.Operator, NodeOperator):
     bl_label = "Align Dependent Nodes"
 
     def execute(self, context):
-        offset = 20
+        offset = getPieMenuSettings().offset
         activeNode = context.active_node
         alignDependent(offset, getNodesWhenFollowingBranchedLinks(activeNode, followOutputs = True))
         return {"FINISHED"}
@@ -39,7 +40,7 @@ class AlignDependenciesNodes(bpy.types.Operator, NodeOperator):
     bl_label = "Align Dependencies"
 
     def execute(self, context):
-        offset = 20
+        offset = getPieMenuSettings().offset
         activeNode = context.active_node
         alignDependencies(offset, getNodesWhenFollowingBranchedLinks(activeNode, followInputs = True))
         return {"FINISHED"}
@@ -77,7 +78,7 @@ class AlignLeftSideSelectionNodes(bpy.types.Operator, NodeOperator):
     bl_label = "Align Left Side Selection Nodes"
 
     def execute(self, context):
-        offset = 20
+        offset = getPieMenuSettings().offset
         activeNode = context.active_node
         activeLocation = activeNode.location
         xOffset = activeNode.width / 2
@@ -94,7 +95,7 @@ class AlignRightSideSelectionNodes(bpy.types.Operator, NodeOperator):
     bl_label = "Align Right Side Selection Nodes"
 
     def execute(self, context):
-        offset = 20
+        offset = getPieMenuSettings().offset
         activeNode = context.active_node
         activeLocation = activeNode.location
         xOffset = activeNode.width / 2
@@ -111,7 +112,7 @@ class StakeUpSelectionNodes(bpy.types.Operator, NodeOperator):
     bl_label = "Stake Up Selection Nodes"
 
     def execute(self, context):
-        offset = 20
+        offset = getPieMenuSettings().offset
         activeNode = context.active_node
         activeLocation = activeNode.location
         yOffset = activeNode.dimensions.y
@@ -128,7 +129,7 @@ class StakeDownSelectionNodes(bpy.types.Operator, NodeOperator):
     bl_label = "Stake Down Selection Nodes"
 
     def execute(self, context):
-        offset = 20
+        offset = getPieMenuSettings().offset
         activeNode = context.active_node
         activeLocation = activeNode.location
         yOffset = activeNode.dimensions.y

--- a/animation_nodes/operators/node_align.py
+++ b/animation_nodes/operators/node_align.py
@@ -162,7 +162,7 @@ def getNodesWhenFollowingBranchedLinks(startNode, followInputs = False, followOu
             sockets.extend(node.outputs)
             for socket in sockets:
                 linkedSockets = getDirectlyLinkedSockets(socket)
-                if len(linkedSockets) > 1:
+                if len(linkedSockets) > 1 or isMultiLinkedSockets(sockets):
                     for linkedSocket in linkedSockets:
                         node = linkedSocket.node
                         nodes.append(getNodesWhenFollowingBranchedLinks(node, followInputs, followOutputs))
@@ -180,3 +180,10 @@ def getLinkedNodes(sockets):
             node = linkedSocket.node
             if node not in nodesLinked: nodesLinked.append(node)
     return nodesLinked
+
+def isMultiLinkedSockets(sockets):
+    count = 0
+    for socket in sockets:
+       if len(getDirectlyLinkedSockets(socket)): count += 1
+       if count > 1: return True
+    return False

--- a/animation_nodes/operators/node_align.py
+++ b/animation_nodes/operators/node_align.py
@@ -26,14 +26,22 @@ def alignDependent(offset, nodes):
         activeLocation = activeNode.location
         xOffset = activeNode.width / 2
         yOffset = activeNode.height / 2
+        lastNode = activeNode
         for node in nodes[1:]:
             if type(node) == list:
                 alignDependent(offset, node)
             else:
                 widthOffset = node.width / 2
                 xOffset += widthOffset + offset
-                node.location = activeLocation + Vector((xOffset, yOffset - node.height / 2))
-                xOffset += widthOffset
+                if node.type != 'REROUTE':
+                    if lastNode.type == 'REROUTE':
+                        activeLocation = node.location
+                        xOffset = node.width / 2
+                        yOffset = node.height / 2
+                    else:
+                        node.location = activeLocation + Vector((xOffset, yOffset - node.height / 2))
+                        xOffset += widthOffset
+                lastNode = node
 
 class AlignDependenciesNodes(bpy.types.Operator, NodeOperator):
     bl_idname = "an.align_dependencies"
@@ -50,14 +58,22 @@ def alignDependencies(offset, nodes):
         activeLocation = activeNode.location
         xOffset = activeNode.width / 2
         yOffset = activeNode.height / 2
+        lastNode = activeNode
         for node in nodes[1:]:
             if type(node) == list:
                 alignDependencies(offset, node)
             else:
                 widthOffset = node.width / 2
                 xOffset += widthOffset + offset
-                node.location = activeLocation + Vector((- xOffset, yOffset - node.height / 2))
-                xOffset += widthOffset
+                if node.type != 'REROUTE':
+                    if lastNode.type == 'REROUTE':
+                        activeLocation = node.location
+                        xOffset = node.width / 2
+                        yOffset = node.height / 2
+                    else:
+                        node.location = activeLocation + Vector((- xOffset, yOffset - node.height / 2))
+                        xOffset += widthOffset
+                lastNode = node
 
 class AlignTopSelectionNodes(bpy.types.Operator, NodeOperator):
     bl_idname = "an.align_top_selection_nodes"

--- a/animation_nodes/operators/node_align.py
+++ b/animation_nodes/operators/node_align.py
@@ -17,15 +17,13 @@ class AlignDependentNodes(bpy.types.Operator, NodeOperator):
     def execute(self, context):
         offset = 20
         activeNode = context.active_node
-        activeNodeWidth = activeNode.width
-        activeNodeHeight = activeNode.height
-        activeNodeCenter = activeNode.location
-        xOffset = activeNodeWidth / 2
-        yOffset = activeNodeHeight / 2
+        activeLocation = activeNode.location
+        xOffset = activeNode.width / 2
+        yOffset = activeNode.height / 2
         for node in getNodesWhenFollowingLinks(activeNode, followOutputs = True):
             widthOffset = node.width / 2
             xOffset += widthOffset + offset
-            node.location = activeNodeCenter + Vector((xOffset, yOffset - node.height / 2))
+            node.location = activeLocation + Vector((xOffset, yOffset - node.height / 2))
             xOffset += widthOffset
         return {"FINISHED"}
 
@@ -36,15 +34,13 @@ class AlignDependenciesNodes(bpy.types.Operator, NodeOperator):
     def execute(self, context):
         offset = 20
         activeNode = context.active_node
-        activeNodeWidth = activeNode.width
-        activeNodeHeight = activeNode.height
-        activeNodeCenter = activeNode.location
-        xOffset = activeNodeWidth / 2
-        yOffset = activeNodeHeight / 2
+        activeLocation = activeNode.location
+        xOffset = activeNode.width / 2
+        yOffset = activeNode.height / 2
         for node in getNodesWhenFollowingLinks(context.active_node, followInputs = True):
             widthOffset = node.width / 2
             xOffset += widthOffset + offset
-            node.location = activeNodeCenter + Vector((- xOffset, yOffset - node.height / 2))
+            node.location = activeLocation + Vector((- xOffset, yOffset - node.height / 2))
             xOffset += widthOffset
         return {"FINISHED"}
 
@@ -54,23 +50,75 @@ class AlignTopSelectionNodes(bpy.types.Operator, NodeOperator):
 
     def execute(self, context):
         activeNode = context.active_node
-        activeNodeCenter = activeNode.location
+        activeLocation = activeNode.location
         yOffset = activeNode.height / 2
         for node in context.selected_nodes:
             if node != activeNode:
                 location = node.location
-                node.location = Vector((location.x, activeNodeCenter.y + yOffset - node.height / 2))
+                node.location = Vector((location.x, activeLocation.y + yOffset - node.height / 2))
         return {"FINISHED"}
 
-class AlignDownSelectionNodes(bpy.types.Operator, NodeOperator):
-    bl_idname = "an.align_down_selection_nodes"
-    bl_label = "Align Down Selection Nodes"
+class AlignLeftSideSelectionNodes(bpy.types.Operator, NodeOperator):
+    bl_idname = "an.align_left_side_selection_nodes"
+    bl_label = "Align Left Side Selection Nodes"
 
     def execute(self, context):
         offset = 20
         activeNode = context.active_node
-        location = activeNode.location.copy()
+        activeLocation = activeNode.location
+        xOffset = activeNode.width / 2
+        for node in context.selected_nodes:
+            if node != activeNode:
+                widthOffset = node.width / 2
+                xOffset += widthOffset + offset
+                node.location.x = activeLocation.x - xOffset
+                xOffset += widthOffset
+        return {"FINISHED"}
+
+class AlignRightSideSelectionNodes(bpy.types.Operator, NodeOperator):
+    bl_idname = "an.align_right_side_selection_nodes"
+    bl_label = "Align Right Side Selection Nodes"
+
+    def execute(self, context):
+        offset = 20
+        activeNode = context.active_node
+        activeLocation = activeNode.location
+        xOffset = activeNode.width / 2
+        for node in context.selected_nodes:
+            if node != activeNode:
+                widthOffset = node.width / 2
+                xOffset += widthOffset + offset
+                node.location.x = activeLocation.x + xOffset
+                xOffset += widthOffset
+        return {"FINISHED"}
+
+class StakeUpSelectionNodes(bpy.types.Operator, NodeOperator):
+    bl_idname = "an.stake_up_selection_nodes"
+    bl_label = "Stake Up Selection Nodes"
+
+    def execute(self, context):
+        offset = 20
+        activeNode = context.active_node
+        activeLocation = activeNode.location
         yOffset = activeNode.dimensions.y
+        location = activeLocation.copy()
+        for node in context.selected_nodes:
+            if node != activeNode:
+                yOffset = node.dimensions.y
+                location.y += (yOffset + offset)
+                node.location = location
+        return {"FINISHED"}
+
+class StakeDownSelectionNodes(bpy.types.Operator, NodeOperator):
+    bl_idname = "an.stake_down_selection_nodes"
+    bl_label = "Stake Down Selection Nodes"
+
+    def execute(self, context):
+        offset = 20
+        activeNode = context.active_node
+        activeLocation = activeNode.location
+        yOffset = activeNode.dimensions.y
+        location = activeLocation.copy()
         for node in context.selected_nodes:
             if node != activeNode:
                 location.y += -(yOffset + offset)

--- a/animation_nodes/operators/node_align.py
+++ b/animation_nodes/operators/node_align.py
@@ -1,0 +1,95 @@
+import bpy
+from mathutils import Vector
+from .. tree_info import getDirectlyLinkedSockets
+
+class NodeOperator:
+    @classmethod
+    def poll(cls, context):
+        tree = context.getActiveAnimationNodeTree()
+        if tree is None: return False
+        if tree.nodes.active is None: return False
+        return True
+
+class AlignDependentNodes(bpy.types.Operator, NodeOperator):
+    bl_idname = "an.align_dependent_nodes"
+    bl_label = "Align Dependent Nodes"
+
+    def execute(self, context):
+        offset = 20
+        activeNode = context.active_node
+        activeNodeWidth = activeNode.width
+        activeNodeHeight = activeNode.height
+        activeNodeCenter = activeNode.location
+        xOffset = activeNodeWidth / 2
+        yOffset = activeNodeHeight / 2
+        for node in getNodesWhenFollowingLinks(activeNode, followOutputs = True):
+            widthOffset = node.width / 2
+            xOffset += widthOffset + offset
+            node.location = activeNodeCenter + Vector((xOffset, yOffset - node.height / 2))
+            xOffset += widthOffset
+        return {"FINISHED"}
+
+class AlignDependenciesNodes(bpy.types.Operator, NodeOperator):
+    bl_idname = "an.align_dependencies"
+    bl_label = "Align Dependencies"
+
+    def execute(self, context):
+        offset = 20
+        activeNode = context.active_node
+        activeNodeWidth = activeNode.width
+        activeNodeHeight = activeNode.height
+        activeNodeCenter = activeNode.location
+        xOffset = activeNodeWidth / 2
+        yOffset = activeNodeHeight / 2
+        for node in getNodesWhenFollowingLinks(context.active_node, followInputs = True):
+            widthOffset = node.width / 2
+            xOffset += widthOffset + offset
+            node.location = activeNodeCenter + Vector((- xOffset, yOffset - node.height / 2))
+            xOffset += widthOffset
+        return {"FINISHED"}
+
+class AlignTopSelectionNodes(bpy.types.Operator, NodeOperator):
+    bl_idname = "an.align_top_selection_nodes"
+    bl_label = "Align Top Selection Nodes"
+
+    def execute(self, context):
+        activeNode = context.active_node
+        activeNodeCenter = activeNode.location
+        yOffset = activeNode.height / 2
+        for node in context.selected_nodes:
+            if node != activeNode:
+                location = node.location
+                node.location = Vector((location.x, activeNodeCenter.y + yOffset - node.height / 2))
+        return {"FINISHED"}
+
+class AlignDownSelectionNodes(bpy.types.Operator, NodeOperator):
+    bl_idname = "an.align_down_selection_nodes"
+    bl_label = "Align Down Selection Nodes"
+
+    def execute(self, context):
+        offset = 20
+        activeNode = context.active_node
+        location = activeNode.location.copy()
+        yOffset = activeNode.dimensions.y
+        for node in context.selected_nodes:
+            if node != activeNode:
+                location.y += -(yOffset + offset)
+                node.location = location
+                yOffset = node.dimensions.y
+        return {"FINISHED"}
+
+def getNodesWhenFollowingLinks(startNode, followInputs = False, followOutputs = False):
+    nodes = []
+    nodesToCheck = {startNode}
+    while nodesToCheck:
+        node = nodesToCheck.pop()
+        nodes.append(node)
+        sockets = []
+        if followInputs: sockets.extend(node.inputs)
+        if followOutputs: sockets.extend(node.outputs)
+        for socket in sockets:
+            for linkedSocket in getDirectlyLinkedSockets(socket):
+                node = linkedSocket.node
+                if node not in nodes: nodesToCheck.add(node)
+    nodes.remove(startNode)
+    return nodes

--- a/animation_nodes/operators/node_align.py
+++ b/animation_nodes/operators/node_align.py
@@ -17,7 +17,7 @@ class AlignDependentNodes(bpy.types.Operator, NodeOperator):
     def execute(self, context):
         offset = 20
         activeNode = context.active_node
-        alignDependent(offset, getNodesWhenFollowingLinksBranched(activeNode, followOutputs = True))
+        alignDependent(offset, getNodesWhenFollowingBranchedLinks(activeNode, followOutputs = True))
         return {"FINISHED"}
 
 def alignDependent(offset, nodes):
@@ -145,14 +145,13 @@ def getNodesWhenFollowingLinks(startNode, followInputs = False, followOutputs = 
         if followOutputs: sockets.extend(node.outputs)
         for socket in sockets:
             linkedSockets = getDirectlyLinkedSockets(socket)
-            if len(linkedSockets) > 1: break
             for linkedSocket in linkedSockets:
                 node = linkedSocket.node
                 if node not in nodes: nodesToCheck.add(node)
     nodes.remove(startNode)
     return nodes
 
-def getNodesWhenFollowingLinksBranched(startNode, followInputs = False, followOutputs = False):
+def getNodesWhenFollowingBranchedLinks(startNode, followInputs = False, followOutputs = False):
     nodes = []
     nodesToCheck = {startNode}
     while nodesToCheck:
@@ -166,7 +165,7 @@ def getNodesWhenFollowingLinksBranched(startNode, followInputs = False, followOu
             if len(linkedSockets) > 1:
                 for linkedSocket in linkedSockets:
                     node = linkedSocket.node
-                    nodes.append(getNodesWhenFollowingLinksBranched(node, followInputs, followOutputs))
+                    nodes.append(getNodesWhenFollowingBranchedLinks(node, followInputs, followOutputs))
             else:
                 for linkedSocket in linkedSockets:
                     node = linkedSocket.node

--- a/animation_nodes/preferences.py
+++ b/animation_nodes/preferences.py
@@ -152,6 +152,13 @@ class DrawHandlerProperties(bpy.types.PropertyGroup):
     bl_idname = "an_DrawHandlerProperties"
     meshIndices: PointerProperty(type = DrawMeshIndicesProperties)
 
+class PieMenuProperties(bpy.types.PropertyGroup):
+    bl_idname = "an_PieMenuProperties"
+
+    offset: FloatProperty(name = "Offset for Align Pie Menu",
+        description = "Offset between nodes for Align Pi Menu",
+        default = 30, soft_min = 0.0, soft_max = 100.0)
+
 class AnimationNodesPreferences(bpy.types.AddonPreferences):
     bl_idname = addonName
 
@@ -159,6 +166,7 @@ class AnimationNodesPreferences(bpy.types.AddonPreferences):
     developer: PointerProperty(type = DeveloperProperties)
     executionCode: PointerProperty(type = ExecutionCodeProperties)
     drawHandlers: PointerProperty(type = DrawHandlerProperties)
+    pieMenuProp: PointerProperty(type = PieMenuProperties)
 
     showUninstallInfo: BoolProperty(name = "Show Deinstall Info", default = False,
         options = {"SKIP_SAVE"})
@@ -179,6 +187,8 @@ class AnimationNodesPreferences(bpy.types.AddonPreferences):
         col = row.column(align = True)
         col.prop(self.developer, "debug")
         col.prop(self.developer, "runTests")
+
+        col.prop(self.pieMenuProp, "offset")
 
         col = layout.column(align = True)
         col.split(factor = 0.25).prop(self, "showUninstallInfo", text = "How to Uninstall?",
@@ -204,6 +214,9 @@ def getColorSettings():
 
 def getMeshIndicesSettings():
     return getPreferences().drawHandlers.meshIndices
+
+def getPieMenuSettings():
+    return getPreferences().pieMenuProp
 
 def debuggingIsEnabled():
     return getPreferences().developer.debug

--- a/animation_nodes/ui/align_pie.py
+++ b/animation_nodes/ui/align_pie.py
@@ -13,13 +13,25 @@ class AlignPie(bpy.types.Menu, PieMenuHelper):
         return True
 
     def drawLeft(self, layout):
-        layout.operator("an.align_dependencies")
+        layout.operator("an.align_dependencies", text = "Dependencies", icon = "ANCHOR_RIGHT")
 
     def drawRight(self, layout):
-        layout.operator("an.align_dependent_nodes")
+        layout.operator("an.align_dependent_nodes", text = "Dependent", icon = "ANCHOR_LEFT")
 
     def drawTop(self, layout):
-        layout.operator("an.align_top_selection_nodes")
+        layout.operator("an.stake_up_selection_nodes", text = "Selection", icon = "ANCHOR_BOTTOM")
 
     def drawBottom(self, layout):
-        layout.operator("an.align_down_selection_nodes")
+        layout.operator("an.stake_down_selection_nodes", text = "Selection", icon = "ANCHOR_TOP")
+
+    def drawTopLeft(self, layout):
+        layout.operator("an.align_top_selection_nodes", text = "Selection", icon = "TRIA_UP_BAR")
+
+    def drawTopRight(self, layout):
+        layout.operator("an.align_top_selection_nodes", text = "Selection", icon = "TRIA_UP_BAR")
+
+    def drawBottomLeft(self, layout):
+        layout.operator("an.align_left_side_selection_nodes", text = "Selection", icon = "TRIA_LEFT_BAR")
+
+    def drawBottomRight(self, layout):
+        layout.operator("an.align_right_side_selection_nodes", text = "Selection", icon = "TRIA_RIGHT_BAR")

--- a/animation_nodes/ui/align_pie.py
+++ b/animation_nodes/ui/align_pie.py
@@ -1,0 +1,25 @@
+import bpy
+from .. utils.blender_ui import PieMenuHelper
+
+class AlignPie(bpy.types.Menu, PieMenuHelper):
+    bl_idname = "AN_MT_align_pie"
+    bl_label = "Align Pie"
+
+    @classmethod
+    def poll(cls, context):
+        tree = context.getActiveAnimationNodeTree()
+        if tree is None: return False
+        if tree.nodes.active is None: return False
+        return True
+
+    def drawLeft(self, layout):
+        layout.operator("an.align_dependencies")
+
+    def drawRight(self, layout):
+        layout.operator("an.align_dependent_nodes")
+
+    def drawTop(self, layout):
+        layout.operator("an.align_top_selection_nodes")
+
+    def drawBottom(self, layout):
+        layout.operator("an.align_down_selection_nodes")


### PR DESCRIPTION
I have added an *Align Pi* menu that allows to align the nodes w.r.t active node. It has eight buttons, two for dependent nodes and dependencies nodes, the other four for selection nodes:
Shortcut Key: F
- Dependencies - That aligns the all dependencies nodes w.r.t active node.
- Dependent  - That aligns the all dependent nodes w.r.t active node.
- Selection (Top)  - That stacks up the all selected nodes w.r.t active node.
- Selection (Down)  - That stacks down the all selected nodes w.r.t active node.
- Selection (Top Right)  - That aligns the headers of all selected nodes w.r.t active node.
- Selection (Top Left)  - That aligns the headers of all selected nodes w.r.t active node.
- Selection (Bottom Right)  - That aligns the sides of all selected nodes w.r.t active node to the right side.
- Selection (Bottom Left)  - That aligns the sides of all selected nodes w.r.t active node to the left side.

![Peek 2020-08-17 13-03](https://user-images.githubusercontent.com/30294746/90370133-82a23a80-e08a-11ea-92ff-5521abbe3e38.gif)

![Screenshot from 2020-08-17 13-04-20](https://user-images.githubusercontent.com/30294746/90370144-8930b200-e08a-11ea-990b-2bd6bbc11039.png)
