### PR TITLE
Fix bl_idname of Evaluate MIDI Track node.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixed
 
-- Fixed `bl_idname` of *Evaluate MIDI Track* node.
+
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Fixed
 
-
+- Fixed `bl_idname` of *Evaluate MIDI Track* node.
 
 ### Changed
 

--- a/animation_nodes/nodes/sound/evaluate_midi_track.py
+++ b/animation_nodes/nodes/sound/evaluate_midi_track.py
@@ -8,7 +8,7 @@ evaluationTypeItems = (
 )
 
 class EvaluateMIDITrackNode(bpy.types.Node, AnimationNode):
-    bl_idname = "an_EvaluateMidiTrackNode"
+    bl_idname = "an_EvaluateMIDITrackNode"
     bl_label = "Evaluate MIDI Track"
 
     evaluationType: EnumProperty(name = "Evaluation Type", default = "SINGLE",
@@ -30,7 +30,7 @@ class EvaluateMIDITrackNode(bpy.types.Node, AnimationNode):
         self.newInput("Interpolation", "Release Interpolation",
                 "releaseInterpolation", defaultDrawType = "PROPERTY_ONLY")
         self.newInput("Scene", "Scene", "scene", hide = True)
-        
+
         if self.evaluationType == "SINGLE":
             self.newOutput("Float", "Note Value", "noteValue")
         else:


### PR DESCRIPTION
I have fixed the `bl_idname` of the **Evaluate MIDI Track** node.