### PR TITLE
Refactor mesh attributes

### DIFF
--- a/animation_nodes/data_structures/attributes/attribute.pyx
+++ b/animation_nodes/data_structures/attributes/attribute.pyx
@@ -19,8 +19,8 @@ cListFromDataType = {
 }
 
 stringFromType = {
-    UV_MAP: "UV_MAP",
     MATERIAL_INDEX: "MATERIAL_INDEX",
+    UV_MAP: "UV_MAP",
     VERTEX_COLOR: "VERTEX_COLOR",
     CUSTOM: "CUSTOM",
 }
@@ -85,13 +85,13 @@ cdef class Attribute:
         self.data = extension + self.data
 
     def getTypeAsString(self):
-        return stringFromType.get((self.type))
+        return stringFromType[self.type]
 
     def getDomainAsString(self):
-        return stringFromDomain.get((self.domain))
+        return stringFromDomain[self.domain]
 
     def getListTypeAsString(self):
-        return stringFromDataType.get((self.dataType))
+        return stringFromDataType[self.dataType]
 
     def getListType(self):
-        return cListFromDataType.get(self.dataType)
+        return cListFromDataType[self.dataType]

--- a/animation_nodes/data_structures/attributes/attribute.pyx
+++ b/animation_nodes/data_structures/attributes/attribute.pyx
@@ -85,13 +85,13 @@ cdef class Attribute:
         self.data = extension + self.data
 
     def getTypeAsString(self):
-        return stringFromType(self.type)
+        return stringFromType.get((self.type))
 
     def getDomainAsString(self):
-        return stringFromDomain(self.domain)
+        return stringFromDomain.get((self.domain))
 
     def getListTypeAsString(self):
-        return stringFromDataType(self.dataType)
+        return stringFromDataType.get((self.dataType))
 
     def getListType(self):
         return cListFromDataType.get(self.dataType)

--- a/animation_nodes/data_structures/meshes/mesh_data.pxd
+++ b/animation_nodes/data_structures/meshes/mesh_data.pxd
@@ -7,4 +7,6 @@ cdef class Mesh:
         readonly EdgeIndicesList edges
         readonly PolygonIndicesList polygons
         dict derivedMeshDataCache
-        object attributes
+        object customAttributes
+        object uvMapAttributes
+        object vertexColorAttributes

--- a/animation_nodes/data_structures/meshes/mesh_data.pxd
+++ b/animation_nodes/data_structures/meshes/mesh_data.pxd
@@ -8,7 +8,7 @@ cdef class Mesh:
         readonly EdgeIndicesList edges
         readonly PolygonIndicesList polygons
         dict derivedMeshDataCache
+        object builtInAttributes
         object customAttributes
         object uvMapAttributes
         object vertexColorAttributes
-        Attribute materialIndices

--- a/animation_nodes/data_structures/meshes/mesh_data.pxd
+++ b/animation_nodes/data_structures/meshes/mesh_data.pxd
@@ -1,3 +1,4 @@
+from .. attributes.attribute cimport Attribute
 from .. lists.polygon_indices_list cimport PolygonIndicesList
 from .. lists.base_lists cimport Vector3DList, EdgeIndicesList, LongList
 
@@ -10,3 +11,4 @@ cdef class Mesh:
         object customAttributes
         object uvMapAttributes
         object vertexColorAttributes
+        Attribute materialIndices

--- a/animation_nodes/data_structures/meshes/mesh_data.pyx
+++ b/animation_nodes/data_structures/meshes/mesh_data.pyx
@@ -208,9 +208,6 @@ cdef class Mesh:
     def getCustomAttribute(self, str name):
         return self.customAttributes.get(name, None)
 
-    def getMaterialIndices(self):
-        return self.getBuiltInAttribute("Material Indices")
-
 
     def getVertexLinkedVertices(self, long vertexIndex):
         cdef LongList neighboursAmounts, neighboursStarts, neighbours, neighbourEdges
@@ -253,7 +250,6 @@ cdef class Mesh:
         self.polygons = newPolygons
         self.derivedMeshDataCache.clear()
         self.builtInAttributes.clear()
-        self.customAttributes.clear()
         self.customAttributes.clear()
         self.uvMapAttributes.clear()
         self.vertexColorAttributes.clear()

--- a/animation_nodes/data_structures/meshes/mesh_data.pyx
+++ b/animation_nodes/data_structures/meshes/mesh_data.pyx
@@ -156,6 +156,8 @@ cdef class Mesh:
             self.uvMapAttributes[attribute.name] = attribute
         elif attribute.type == AttributeType.VERTEX_COLOR:
             self.vertexColorAttributes[attribute.name] = attribute
+        elif attribute.type == AttributeType.MATERIAL_INDEX:
+            self.materialIndices = attribute
         else:
             self.customAttributes[attribute.name] = attribute
 

--- a/animation_nodes/nodes/mesh/bmesh_create.py
+++ b/animation_nodes/nodes/mesh/bmesh_create.py
@@ -33,7 +33,7 @@ def getBMeshFromMesh(meshData):
     for edgeIndices in meshData.edges:
         bm.edges.new((bm.verts[edgeIndices[0]], bm.verts[edgeIndices[1]]))
 
-    materialIndices = meshData.getMaterialIndices()
+    materialIndices = meshData.getBuiltInAttribute("Material Indices")
     if materialIndices is not None:
         materialIndicesData = materialIndices.data
         for polygonIndices, materialIndex in zip(meshData.polygons, materialIndicesData):

--- a/animation_nodes/nodes/mesh/combine_mesh_data.py
+++ b/animation_nodes/nodes/mesh/combine_mesh_data.py
@@ -43,9 +43,9 @@ class CombineMeshNode(bpy.types.Node, AnimationNode):
             mesh = Mesh(vertexLocations, edgeIndices, polygonIndices, skipValidation = self.skipValidation)
             if self.inputs["Material Indices"].isUsed:
                 if len(materialIndices) == len(polygonIndices) and materialIndices.getMinValue() >= 0:
-                    mesh.insertAttribute(Attribute("Material Indices", AttributeType.MATERIAL_INDEX,
-                                                   AttributeDomain.FACE, AttributeDataType.INT,
-                                                   materialIndices))
+                    mesh.insertBuiltInAttribute(Attribute("Material Indices", AttributeType.MATERIAL_INDEX,
+                                                          AttributeDomain.FACE, AttributeDataType.INT,
+                                                          materialIndices))
                 else:
                     self.raiseErrorMessage("Invalid material indices.")
             return mesh

--- a/animation_nodes/nodes/mesh/get_custom_attribute.py
+++ b/animation_nodes/nodes/mesh/get_custom_attribute.py
@@ -1,11 +1,11 @@
 import bpy
 from bpy.props import *
 from ... base_types import AnimationNode
-from ... data_structures import DoubleList
+from ... data_structures import DoubleList, AttributeType
 
 dataTypeItems = [
-    ("FLOAT", "Float", "", "NONE", 0),
-    ("INT", "Integer", "", "NONE", 1),
+    ("INT", "Integer", "", "NONE", 0),
+    ("FLOAT", "Float", "", "NONE", 1),
     ("FLOAT2", "Float2", "", "NONE", 2),
     ("FLOAT_VECTOR", "Vector", "", "NONE", 3),
     ("FLOAT_COLOR", "Color", "", "NONE", 4),
@@ -45,14 +45,10 @@ class GetCustomAttributeNode(bpy.types.Node, AnimationNode):
         layout.prop(self, "dataType", text = "")
 
     def execute(self, mesh, attributeName):
-        if mesh is None: return None, None, None
+        if mesh is None: return None, None, None, None
         if attributeName == "": self.raiseErrorMessage("Attribute name can't be empty.")
 
-        attributes = mesh.getAllAttributes()
-        attribute = attributes.get(attributeName, None)
-        if attribute is None:
-            self.raiseErrorMessage(f"""Object does not have attribute with name '{attributeName}'.\nAvailable: {self.getAttributeNames(attributes)}""")
-
+        attribute = self.getPossibleAttribute(attributeName, mesh)
         if self.dataType != attribute.getListTypeAsString():
             self.raiseErrorMessage("Wrong output data type.")
 
@@ -60,6 +56,20 @@ class GetCustomAttributeNode(bpy.types.Node, AnimationNode):
             return DoubleList.fromValues(attribute.data), attribute.getTypeAsString(), attribute.getDomainAsString(), self.dataType
         return attribute.data, attribute.getTypeAsString(), attribute.getDomainAsString(), self.dataType
 
-    def getAttributeNames(self, attributes):
-        attributesNames = [key for key in attributes.keys()]
-        return attributesNames
+    def getPossibleAttribute(self, attributeName, mesh):
+        attribute = mesh.getAttribute(attributeName, AttributeType.CUSTOM)
+        if attribute is not None: return attribute
+
+        attribute = mesh.getAttribute(attributeName, AttributeType.UV_MAP)
+        if attribute is not None: return attribute
+
+        attribute = mesh.getAttribute(attributeName, AttributeType.VERTEX_COLOR)
+        if attribute is not None: return attribute
+
+        self.raiseErrorMessage(f"""Object does not have attribute with name '{attributeName}'.\nAvailable: {self.getAttributeNames(mesh)}""")
+
+    def getAttributeNames(self, mesh):
+        attributeNames = list()
+        for (meshAttributes, _) in mesh.getMeshAttributes():
+            attributeNames.extend(meshAttributes.keys())
+        return attributeNames

--- a/animation_nodes/nodes/mesh/get_custom_attribute.py
+++ b/animation_nodes/nodes/mesh/get_custom_attribute.py
@@ -57,19 +57,22 @@ class GetCustomAttributeNode(bpy.types.Node, AnimationNode):
         return attribute.data, attribute.getTypeAsString(), attribute.getDomainAsString(), self.dataType
 
     def getPossibleAttribute(self, attributeName, mesh):
-        attribute = mesh.getAttribute(attributeName, AttributeType.CUSTOM)
+        attribute = mesh.getCustomAttribute(attributeName)
         if attribute is not None: return attribute
 
-        attribute = mesh.getAttribute(attributeName, AttributeType.UV_MAP)
+        attribute = mesh.getBuiltInAttribute(attributeName)
         if attribute is not None: return attribute
 
-        attribute = mesh.getAttribute(attributeName, AttributeType.VERTEX_COLOR)
+        attribute = mesh.getUVMapAttribute(attributeName)
+        if attribute is not None: return attribute
+
+        attribute = mesh.getVertexColorAttribute(attributeName)
         if attribute is not None: return attribute
 
         self.raiseErrorMessage(f"""Object does not have attribute with name '{attributeName}'.\nAvailable: {self.getAttributeNames(mesh)}""")
 
     def getAttributeNames(self, mesh):
         attributeNames = list()
-        for (meshAttributes, _) in mesh.getMeshAttributes():
+        for meshAttributes in mesh.getAttributeDictionaries():
             attributeNames.extend(meshAttributes.keys())
         return attributeNames

--- a/animation_nodes/nodes/mesh/get_custom_attribute.py
+++ b/animation_nodes/nodes/mesh/get_custom_attribute.py
@@ -1,7 +1,7 @@
 import bpy
 from bpy.props import *
 from ... base_types import AnimationNode
-from ... data_structures import DoubleList, AttributeType
+from ... data_structures import DoubleList
 
 dataTypeItems = [
     ("INT", "Integer", "", "NONE", 0),
@@ -48,31 +48,13 @@ class GetCustomAttributeNode(bpy.types.Node, AnimationNode):
         if mesh is None: return None, None, None, None
         if attributeName == "": self.raiseErrorMessage("Attribute name can't be empty.")
 
-        attribute = self.getPossibleAttribute(attributeName, mesh)
+        attribute = mesh.getCustomAttribute(attributeName)
+        if attribute is None:
+            self.raiseErrorMessage(f"""Object does not have attribute with name '{attributeName}'.\nAvailable: {mesh.getAllCustomAttributeNames()}""")
+
         if self.dataType != attribute.getListTypeAsString():
             self.raiseErrorMessage("Wrong output data type.")
 
         if self.dataType == "FLOAT":
             return DoubleList.fromValues(attribute.data), attribute.getTypeAsString(), attribute.getDomainAsString(), self.dataType
         return attribute.data, attribute.getTypeAsString(), attribute.getDomainAsString(), self.dataType
-
-    def getPossibleAttribute(self, attributeName, mesh):
-        attribute = mesh.getCustomAttribute(attributeName)
-        if attribute is not None: return attribute
-
-        attribute = mesh.getBuiltInAttribute(attributeName)
-        if attribute is not None: return attribute
-
-        attribute = mesh.getUVMapAttribute(attributeName)
-        if attribute is not None: return attribute
-
-        attribute = mesh.getVertexColorAttribute(attributeName)
-        if attribute is not None: return attribute
-
-        self.raiseErrorMessage(f"""Object does not have attribute with name '{attributeName}'.\nAvailable: {self.getAttributeNames(mesh)}""")
-
-    def getAttributeNames(self, mesh):
-        attributeNames = list()
-        for meshAttributes in mesh.getAttributeDictionaries():
-            attributeNames.extend(meshAttributes.keys())
-        return attributeNames

--- a/animation_nodes/nodes/mesh/get_uv_map.py
+++ b/animation_nodes/nodes/mesh/get_uv_map.py
@@ -17,7 +17,7 @@ class GetUVMapNode(bpy.types.Node, AnimationNode):
         if uvMapName == "":
             self.raiseErrorMessage("UV map name can't be empty.")
 
-        uvMap = mesh.getAttribute(uvMapName, AttributeType.UV_MAP)
+        uvMap = mesh.getUVMapAttribute(uvMapName)
         if uvMap is None:
             self.raiseErrorMessage(f"Mesh doesn't have a uv map with the name '{uvMapName}'.")
 

--- a/animation_nodes/nodes/mesh/get_vertex_color_layer.py
+++ b/animation_nodes/nodes/mesh/get_vertex_color_layer.py
@@ -34,7 +34,7 @@ class GetVertexColorLayerNode(bpy.types.Node, AnimationNode):
 
         defaultColor = Color((0, 0, 0, 1))
 
-        vertexColor = mesh.getAttribute(colorLayerName, AttributeType.VERTEX_COLOR)
+        vertexColor = mesh.getVertexColorAttribute(colorLayerName)
         if vertexColor is None:
             self.raiseErrorMessage(f"Mesh doesn't have a vertex color layer with the name '{colorLayerName}'.")
 

--- a/animation_nodes/nodes/mesh/insert_custom_attribute.py
+++ b/animation_nodes/nodes/mesh/insert_custom_attribute.py
@@ -25,8 +25,8 @@ domainItems = [
 ]
 
 dataTypeItems = [
-    ("FLOAT", "Float", "", "NONE", 0),
-    ("INT", "Integer", "", "NONE", 1),
+    ("INT", "Integer", "", "NONE", 0),
+    ("FLOAT", "Float", "", "NONE", 1),
     ("FLOAT2", "Float2", "", "NONE", 2),
     ("FLOAT_VECTOR", "Vector", "", "NONE", 3),
     ("FLOAT_COLOR", "Color", "", "NONE", 4),
@@ -49,12 +49,12 @@ class InsertCustomAttributeNode(bpy.types.Node, AnimationNode):
 
     def create(self):
         self.newInput("Mesh", "Mesh", "mesh", dataIsModified = True)
-        self.newInput("Text", "Attribute Name", "attributeName", value = "AN-Att")
-        if self.dataType == "FLOAT":
-            self.newInput(VectorizedSocket("Float", "useDataList",
-            ("Value", "data"), ("Values", "data")))
-        elif self.dataType == "INT":
+        self.newInput("Text", "Name", "customAttributeName", value = "AN-Att")
+        if self.dataType == "INT":
             self.newInput(VectorizedSocket("Integer", "useDataList",
+            ("Value", "data"), ("Values", "data")))
+        elif self.dataType == "FLOAT":
+            self.newInput(VectorizedSocket("Float", "useDataList",
             ("Value", "data"), ("Values", "data")))
         elif self.dataType == "FLOAT2":
             self.newInput(VectorizedSocket("Vector 2D", "useDataList",
@@ -75,16 +75,8 @@ class InsertCustomAttributeNode(bpy.types.Node, AnimationNode):
         layout.prop(self, "domain", text = "")
         layout.prop(self, "dataType", text = "")
 
-    def execute(self, mesh, attributeName, data):
-        if mesh is None: return mesh
-
-        if attributeName == "":
-            self.raiseErrorMessage("Attribute name can't be empty.")
-        elif self.domain == "CORNER" and self.dataType == "BYTE_COLOR":
-            if attributeName in [*mesh.getAttributeNames(AttributeType.CUSTOM), *mesh.getAttributeNames(AttributeType.VERTEX_COLOR)]:
-                self.raiseErrorMessage(f"Mesh has already a custom attribute / vertex color layer with the name '{attributeName}'.")
-        elif attributeName in mesh.getAttributeNames(AttributeType.CUSTOM):
-            self.raiseErrorMessage(f"Mesh has already a custom attribute with the name '{attributeName}'.")
+    def execute(self, mesh, customAttributeName, data):
+        self.checkAttributeName(mesh, customAttributeName)
 
         if self.domain == "POINT":
             amount = len(mesh.vertices)
@@ -95,10 +87,10 @@ class InsertCustomAttributeNode(bpy.types.Node, AnimationNode):
         else:
             amount = len(mesh.polygons.indices)
 
-        if self.dataType == "FLOAT":
-            _data = FloatList.fromValues(VirtualDoubleList.create(data, 0).materialize(amount))
-        elif self.dataType == "INT":
+        if self.dataType == "INT":
             _data = VirtualLongList.create(data, 0).materialize(amount)
+        elif self.dataType == "FLOAT":
+            _data = FloatList.fromValues(VirtualDoubleList.create(data, 0).materialize(amount))
         elif self.dataType == "FLOAT2":
             _data = VirtualVector2DList.create(data, Vector((0, 0))).materialize(amount)
         elif self.dataType == "FLOAT_VECTOR":
@@ -108,6 +100,12 @@ class InsertCustomAttributeNode(bpy.types.Node, AnimationNode):
         else:
             _data = VirtualBooleanList.create(data, False).materialize(amount)
 
-        mesh.insertAttribute(Attribute(attributeName, AttributeType.CUSTOM, AttributeDomain[self.domain],
-                                       AttributeDataType[self.dataType], _data))
+        mesh.insertCustomAttribute(Attribute(customAttributeName, AttributeType.CUSTOM, AttributeDomain[self.domain],
+                                             AttributeDataType[self.dataType], _data))
         return mesh
+
+    def checkAttributeName(self, mesh, attributeName):
+        if attributeName == "":
+            self.raiseErrorMessage("Custom attribute name can't be empty.")
+        elif attributeName in mesh.getAllCustomAttributeNames():
+            self.raiseErrorMessage(f"Mesh has already a custom attribute with the name '{attributeName}'.")

--- a/animation_nodes/nodes/mesh/insert_custom_attribute.py
+++ b/animation_nodes/nodes/mesh/insert_custom_attribute.py
@@ -48,7 +48,7 @@ class InsertCustomAttributeNode(bpy.types.Node, AnimationNode):
     useDataList: VectorizedSocket.newProperty()
 
     def create(self):
-        self.newInput("Mesh", "Mesh", "mesh")
+        self.newInput("Mesh", "Mesh", "mesh", dataIsModified = True)
         self.newInput("Text", "Attribute Name", "attributeName", value = "AN-Att")
         if self.dataType == "FLOAT":
             self.newInput(VectorizedSocket("Float", "useDataList",
@@ -80,8 +80,11 @@ class InsertCustomAttributeNode(bpy.types.Node, AnimationNode):
 
         if attributeName == "":
             self.raiseErrorMessage("Attribute name can't be empty.")
+        elif self.domain == "CORNER" and self.dataType == "BYTE_COLOR":
+            if attributeName in [*mesh.getAttributeNames(AttributeType.CUSTOM), *mesh.getAttributeNames(AttributeType.VERTEX_COLOR)]:
+                self.raiseErrorMessage(f"Mesh has already a custom attribute / vertex color layer with the name '{attributeName}'.")
         elif attributeName in mesh.getAttributeNames(AttributeType.CUSTOM):
-            self.raiseErrorMessage(f"Mesh has already a vertex color layer with the name '{attributeName}'.")
+            self.raiseErrorMessage(f"Mesh has already a custom attribute with the name '{attributeName}'.")
 
         if self.domain == "POINT":
             amount = len(mesh.vertices)

--- a/animation_nodes/nodes/mesh/insert_uv_map.py
+++ b/animation_nodes/nodes/mesh/insert_uv_map.py
@@ -25,12 +25,15 @@ class InsertUVMapNode(bpy.types.Node, AnimationNode):
         self.newOutput("Mesh", "Mesh", "mesh")
 
     def execute(self, mesh, uvMapName, positions):
-        if uvMapName == "":
-            self.raiseErrorMessage("UV map name can't be empty.")
-        elif uvMapName in mesh.getAttributeNames(AttributeType.UV_MAP):
-            self.raiseErrorMessage(f"Mesh already has a uv map with the name '{uvMapName}'.")
+        self.checkAttributeName(mesh, uvMapName)
 
         positions = VirtualVector2DList.create(positions, Vector((0, 0))).materialize(len(mesh.polygons.indices))
-        mesh.insertAttribute(Attribute(uvMapName, AttributeType.UV_MAP, AttributeDomain.CORNER,
-                                       AttributeDataType.FLOAT2, positions))
+        mesh.insertUVMapAttribute(Attribute(uvMapName, AttributeType.UV_MAP, AttributeDomain.CORNER,
+                                            AttributeDataType.FLOAT2, positions))
         return mesh
+
+    def checkAttributeName(self, mesh, attributeName):
+        if attributeName == "":
+            self.raiseErrorMessage("UV map name can't be empty.")
+        elif attributeName in mesh.getAllUVMapAttributeNames():
+            self.raiseErrorMessage(f"Mesh has already a uv map with the name '{attributeName}'.")

--- a/animation_nodes/nodes/mesh/insert_vertex_color_layer.py
+++ b/animation_nodes/nodes/mesh/insert_vertex_color_layer.py
@@ -47,23 +47,17 @@ class InsertVertexColorLayerNode(bpy.types.Node, AnimationNode):
             return "execute_SingleColor"
 
     def execute_SingleColor(self, mesh, colorLayerName, color):
-        if colorLayerName == "":
-            self.raiseErrorMessage("Vertex color layer name can't be empty.")
-        elif colorLayerName in mesh.getAttributeNames(AttributeType.VERTEX_COLOR):
-            self.raiseErrorMessage(f"Mesh has already a vertex color layer with the name '{colorLayerName}'.")
+        self.checkAttributeName(mesh, colorLayerName)
 
         defaultColor = Color((0, 0, 0, 1))
         colorsList = VirtualColorList.create(color, defaultColor).materialize(len(mesh.polygons.indices))
 
-        mesh.insertAttribute(colorLayerName, AttributeType.VERTEX_COLOR, AttributeDomain.CORNER,
-                             AttributeDataType.BYTE_COLOR, colorsList)
+        mesh.insertAttribute(Attribute(colorLayerName, AttributeType.VERTEX_COLOR, AttributeDomain.CORNER,
+                                       AttributeDataType.BYTE_COLOR, colorsList))
         return mesh
 
     def execute_ColorsList(self, mesh, colorLayerName, colors):
-        if colorLayerName == "":
-            self.raiseErrorMessage("Vertex color layer name can't be empty.")
-        elif colorLayerName in mesh.getAttributeNames(AttributeType.VERTEX_COLOR):
-            self.raiseErrorMessage(f"Mesh has already a vertex color layer with the name '{colorLayerName}'.")
+        self.checkAttributeName(mesh, colorLayerName)
 
         defaultColor = Color((0, 0, 0, 1))
         colorsList = VirtualColorList.create(colors, defaultColor)
@@ -77,6 +71,12 @@ class InsertVertexColorLayerNode(bpy.types.Node, AnimationNode):
             polygonIndices = mesh.polygons
             colorsList = getLoopColorsFromPolygonColors(polygonIndices, colorsList)
 
-        mesh.insertAttribute(Attribute(colorLayerName, AttributeType.CUSTOM, AttributeDomain.CORNER,
+        mesh.insertAttribute(Attribute(colorLayerName, AttributeType.VERTEX_COLOR, AttributeDomain.CORNER,
                                        AttributeDataType.BYTE_COLOR, colorsList))
         return mesh
+
+    def checkAttributeName(self, mesh, colorLayerName):
+        if colorLayerName == "":
+            self.raiseErrorMessage("Vertex color layer name can't be empty.")
+        elif colorLayerName in [*mesh.getAttributeNames(AttributeType.CUSTOM), *mesh.getAttributeNames(AttributeType.VERTEX_COLOR)]:
+            self.raiseErrorMessage(f"Mesh has already a vertex color layer with the name '{colorLayerName}'.")

--- a/animation_nodes/nodes/mesh/insert_vertex_color_layer.py
+++ b/animation_nodes/nodes/mesh/insert_vertex_color_layer.py
@@ -52,8 +52,8 @@ class InsertVertexColorLayerNode(bpy.types.Node, AnimationNode):
         defaultColor = Color((0, 0, 0, 1))
         colorsList = VirtualColorList.create(color, defaultColor).materialize(len(mesh.polygons.indices))
 
-        mesh.insertAttribute(Attribute(colorLayerName, AttributeType.VERTEX_COLOR, AttributeDomain.CORNER,
-                                       AttributeDataType.BYTE_COLOR, colorsList))
+        mesh.insertVertexColorAttribute(Attribute(colorLayerName, AttributeType.VERTEX_COLOR, AttributeDomain.CORNER,
+                                                  AttributeDataType.BYTE_COLOR, colorsList))
         return mesh
 
     def execute_ColorsList(self, mesh, colorLayerName, colors):
@@ -71,12 +71,12 @@ class InsertVertexColorLayerNode(bpy.types.Node, AnimationNode):
             polygonIndices = mesh.polygons
             colorsList = getLoopColorsFromPolygonColors(polygonIndices, colorsList)
 
-        mesh.insertAttribute(Attribute(colorLayerName, AttributeType.VERTEX_COLOR, AttributeDomain.CORNER,
-                                       AttributeDataType.BYTE_COLOR, colorsList))
+        mesh.insertVertexColorAttribute(Attribute(colorLayerName, AttributeType.VERTEX_COLOR, AttributeDomain.CORNER,
+                                                  AttributeDataType.BYTE_COLOR, colorsList))
         return mesh
 
-    def checkAttributeName(self, mesh, colorLayerName):
-        if colorLayerName == "":
+    def checkAttributeName(self, mesh, attributeName):
+        if attributeName == "":
             self.raiseErrorMessage("Vertex color layer name can't be empty.")
-        elif colorLayerName in [*mesh.getAttributeNames(AttributeType.CUSTOM), *mesh.getAttributeNames(AttributeType.VERTEX_COLOR)]:
-            self.raiseErrorMessage(f"Mesh has already a vertex color layer with the name '{colorLayerName}'.")
+        elif attributeName in mesh.getAllVertexColorAttributeNames():
+            self.raiseErrorMessage(f"Mesh has already a vertex color layer with the name '{attributeName}'.")

--- a/animation_nodes/nodes/mesh/mesh_info.py
+++ b/animation_nodes/nodes/mesh/mesh_info.py
@@ -42,7 +42,7 @@ class MeshInfoNode(bpy.types.Node, AnimationNode):
             yield "customAttributeNames = mesh.getAttributeNames(AttributeType.CUSTOM)"
 
     def getMaterialIndices(self, mesh):
-        materialIndices = mesh.getMaterialIndices()
+        materialIndices = mesh.getBuiltInAttribute("Material Indices")
         if materialIndices is None:
             indices = LongList(length = len(mesh.polygons))
             indices.fill(0)

--- a/animation_nodes/nodes/mesh/mesh_object_input.py
+++ b/animation_nodes/nodes/mesh/mesh_object_input.py
@@ -121,33 +121,33 @@ class MeshObjectInputNode(bpy.types.Node, AnimationNode):
 
     def loadMaterialIndices(self, type, mesh, sourceMesh, object):
         if object.mode != "EDIT":
-            mesh.insertAttribute(Attribute("Material Indices",
-                                           AttributeType.MATERIAL_INDEX,
-                                           AttributeDomain.FACE,
-                                           AttributeDataType.INT,
-                                           sourceMesh.an.getPolygonMaterialIndices()))
+            mesh.insertBuiltInAttribute(Attribute("Material Indices",
+                                                  AttributeType.MATERIAL_INDEX,
+                                                  AttributeDomain.FACE,
+                                                  AttributeDataType.INT,
+                                                  sourceMesh.an.getPolygonMaterialIndices()))
         else:
             self.setErrorMessage("Object is in edit mode.")
 
     def loadUVMaps(self, type, mesh, sourceMesh, object):
         if object.mode != "EDIT":
             for uvMapName in sourceMesh.uv_layers.keys():
-                mesh.insertAttribute(Attribute(uvMapName,
-                                               AttributeType.UV_MAP,
-                                               AttributeDomain.CORNER,
-                                               AttributeDataType.FLOAT2,
-                                               sourceMesh.an.getUVMap(uvMapName)))
+                mesh.insertUVMapAttribute(Attribute(uvMapName,
+                                                    AttributeType.UV_MAP,
+                                                    AttributeDomain.CORNER,
+                                                    AttributeDataType.FLOAT2,
+                                                    sourceMesh.an.getUVMap(uvMapName)))
         else:
             self.setErrorMessage("Object is in edit mode.")
 
     def loadVertexColors(self, type, mesh, sourceMesh, object):
         if object.mode != "EDIT":
             for colorLayerName in sourceMesh.vertex_colors.keys():
-                mesh.insertAttribute(Attribute(colorLayerName,
-                                               AttributeType.VERTEX_COLOR,
-                                               AttributeDomain.CORNER,
-                                               AttributeDataType.BYTE_COLOR,
-                                               sourceMesh.an.getVertexColorLayer(colorLayerName)))
+                mesh.insertVertexColorAttribute(Attribute(colorLayerName,
+                                                          AttributeType.VERTEX_COLOR,
+                                                          AttributeDomain.CORNER,
+                                                          AttributeDataType.BYTE_COLOR,
+                                                          sourceMesh.an.getVertexColorLayer(colorLayerName)))
         else:
             self.setErrorMessage("Object is in edit mode.")
 
@@ -156,10 +156,10 @@ class MeshObjectInputNode(bpy.types.Node, AnimationNode):
             attributes = object.data.attributes
             for customAttributeName in attributes.keys():
                 attribute = attributes.get(customAttributeName)
-                mesh.insertAttribute(Attribute(customAttributeName,
-                                               AttributeType.CUSTOM,
-                                               AttributeDomain[attribute.domain],
-                                               AttributeDataType[attribute.data_type],
-                                               object.data.an.getCustomAttribute(customAttributeName)))
+                mesh.insertCustomAttribute(Attribute(customAttributeName,
+                                                     AttributeType.CUSTOM,
+                                                     AttributeDomain[attribute.domain],
+                                                     AttributeDataType[attribute.data_type],
+                                                     object.data.an.getCustomAttribute(customAttributeName)))
         else:
             self.setErrorMessage("Object is in edit mode.")

--- a/animation_nodes/nodes/mesh/mesh_object_input.py
+++ b/animation_nodes/nodes/mesh/mesh_object_input.py
@@ -144,7 +144,7 @@ class MeshObjectInputNode(bpy.types.Node, AnimationNode):
         if object.mode != "EDIT":
             for colorLayerName in sourceMesh.vertex_colors.keys():
                 mesh.insertAttribute(Attribute(colorLayerName,
-                                               AttributeType.CUSTOM,
+                                               AttributeType.VERTEX_COLOR,
                                                AttributeDomain.CORNER,
                                                AttributeDataType.BYTE_COLOR,
                                                sourceMesh.an.getVertexColorLayer(colorLayerName)))

--- a/animation_nodes/nodes/mesh/mesh_object_output.py
+++ b/animation_nodes/nodes/mesh/mesh_object_output.py
@@ -137,6 +137,11 @@ class MeshObjectOutputNode(bpy.types.Node, AnimationNode):
             outMesh.uv_layers.new(name = name)
             outMesh.uv_layers[name].data.foreach_set("uv", uvMap.data.asMemoryView())
 
+        # Vertex Color Layers
+        for name, vertexColors in mesh.getAttributes(AttributeType.VERTEX_COLOR):
+            outMesh.vertex_colors.new(name = name)
+            outMesh.vertex_colors[name].data.foreach_set("color", vertexColors.data.asMemoryView())
+
         # Custom Attributes
         for name, attribute in mesh.getAttributes(AttributeType.CUSTOM):
             attributeOut = outMesh.attributes.get(name)

--- a/animation_nodes/nodes/mesh/mesh_object_output.py
+++ b/animation_nodes/nodes/mesh/mesh_object_output.py
@@ -125,7 +125,7 @@ class MeshObjectOutputNode(bpy.types.Node, AnimationNode):
         outMesh.loops.foreach_set("edge_index", mesh.getLoopEdges().asMemoryView())
 
         # Materials Indices
-        materialIndices = mesh.getMaterialIndices()
+        materialIndices = mesh.getBuiltInAttribute("Material Indices")
         if materialIndices is not None:
             indices = materialIndices.data
             if len(indices) > 0 and indices.getMaxValue() > 0 and indices.getMinValue() >= 0:
@@ -133,17 +133,17 @@ class MeshObjectOutputNode(bpy.types.Node, AnimationNode):
                 outMesh.polygons.foreach_set("material_index", indices.asMemoryView())
 
         # UV Maps
-        for name, uvMap in mesh.getAttributes(AttributeType.UV_MAP):
+        for name, uvMap in mesh.getAllUVMapAttributes():
             outMesh.uv_layers.new(name = name)
             outMesh.uv_layers[name].data.foreach_set("uv", uvMap.data.asMemoryView())
 
         # Vertex Color Layers
-        for name, vertexColors in mesh.getAttributes(AttributeType.VERTEX_COLOR):
+        for name, vertexColors in mesh.getAllVertexColorAttributes():
             outMesh.vertex_colors.new(name = name)
             outMesh.vertex_colors[name].data.foreach_set("color", vertexColors.data.asMemoryView())
 
         # Custom Attributes
-        for name, attribute in mesh.getAttributes(AttributeType.CUSTOM):
+        for name, attribute in mesh.getAllCustomAttributes():
             attributeOut = outMesh.attributes.get(name)
 
             domain = attribute.getDomainAsString()

--- a/animation_nodes/nodes/mesh/set_custom_attribute.py
+++ b/animation_nodes/nodes/mesh/set_custom_attribute.py
@@ -21,8 +21,8 @@ domainItems = [
 ]
 
 dataTypeItems = [
-    ("FLOAT", "Float", "", "NONE", 0),
-    ("INT", "Integer", "", "NONE", 1),
+    ("INT", "Integer", "", "NONE", 0),
+    ("FLOAT", "Float", "", "NONE", 1),
     ("FLOAT2", "Float2", "", "NONE", 2),
     ("FLOAT_VECTOR", "Vector", "", "NONE", 3),
     ("FLOAT_COLOR", "Color", "", "NONE", 4),
@@ -45,12 +45,12 @@ class SetCustomAttributeNode(bpy.types.Node, AnimationNode):
 
     def create(self):
         self.newInput("Object", "Object", "object", defaultDrawType = "PROPERTY_ONLY")
-        self.newInput("Text", "Attribute Name", "attributeName", value = "AN-Att")
-        if self.dataType == "FLOAT":
-            self.newInput(VectorizedSocket("Float", "useDataList",
-            ("Value", "data"), ("Values", "data")))
-        elif self.dataType == "INT":
+        self.newInput("Text", "Name", "customAttributeName", value = "AN-Att")
+        if self.dataType == "INT":
             self.newInput(VectorizedSocket("Integer", "useDataList",
+            ("Value", "data"), ("Values", "data")))
+        elif self.dataType == "FLOAT":
+            self.newInput(VectorizedSocket("Float", "useDataList",
             ("Value", "data"), ("Values", "data")))
         elif self.dataType == "FLOAT2":
             self.newInput(VectorizedSocket("Vector 2D", "useDataList",
@@ -71,17 +71,17 @@ class SetCustomAttributeNode(bpy.types.Node, AnimationNode):
         layout.prop(self, "domain", text = "")
         layout.prop(self, "dataType", text = "")
 
-    def execute(self, object, attributeName, data):
+    def execute(self, object, customAttributeName, data):
         if object is None: return object
         if object.type != "MESH": self.raiseErrorMessage("Object should be Mesh type.")
-        if attributeName == "": self.raiseErrorMessage("Attribute name can't be empty.")
+        if customAttributeName == "": self.raiseErrorMessage("Attribute name can't be empty.")
 
-        attribute = object.data.attributes.get(attributeName)
+        attribute = object.data.attributes.get(customAttributeName)
         if attribute is None:
-            attribute = object.data.attributes.new(attributeName, self.dataType, self.domain)
+            attribute = object.data.attributes.new(customAttributeName, self.dataType, self.domain)
         elif attribute.data_type != self.dataType or attribute.domain != self.domain:
             object.data.attributes.remove(attribute)
-            attribute = object.data.attributes.new(attributeName, self.dataType, self.domain)
+            attribute = object.data.attributes.new(customAttributeName, self.dataType, self.domain)
 
         if self.domain == "POINT":
             amount = len(object.data.vertices)
@@ -92,10 +92,10 @@ class SetCustomAttributeNode(bpy.types.Node, AnimationNode):
         else:
             amount = len(object.data.loops)
 
-        if self.dataType == "FLOAT":
-            _data = FloatList.fromValues(VirtualDoubleList.create(data, 0).materialize(amount))
-        elif self.dataType == "INT":
+        if self.dataType == "INT":
             _data = VirtualLongList.create(data, 0).materialize(amount)
+        elif self.dataType == "FLOAT":
+            _data = FloatList.fromValues(VirtualDoubleList.create(data, 0).materialize(amount))
         elif attribute.data_type == "FLOAT2":
             _data = VirtualVector2DList.create(data, Vector((0, 0))).materialize(amount)
         elif self.dataType == "FLOAT_VECTOR":

--- a/animation_nodes/nodes/mesh/triangulate_mesh.py
+++ b/animation_nodes/nodes/mesh/triangulate_mesh.py
@@ -28,7 +28,7 @@ class TriangulateMeshNode(bpy.types.Node, AnimationNode):
             mesh.triangulateMesh(method = "FAN")
 
         try:
-            checkMeshData(mesh.vertices, mesh.edges, mesh.polygons, mesh.materialIndices)
+            checkMeshData(mesh.vertices, mesh.edges, mesh.polygons)
             return mesh
         except Exception as e:
             self.raiseErrorMessage(str(e))


### PR DESCRIPTION
In this patch, I have refactored the mesh attribute storage as discussed here https://github.com/JacquesLucke/animation_nodes/commit/558dc15219eae4780517744b0e9c9afbefbebcac#commitcomment-49758333. Now, it is possible to have different type of attributes with the same name. 

The *UV Map* and *Vertex Color* attributes have their own dictionary for storage. However, the *Custom* and *Material Indices* attributes share the same dictionary for storage.
