### PR TITLE
Add FastNoiseSIMD_neon to support arm64 macOS

### DIFF
--- a/animation_nodes/libs/FastNoiseSIMD/source/FastNoiseSIMD_neon.cpp
+++ b/animation_nodes/libs/FastNoiseSIMD/source/FastNoiseSIMD_neon.cpp
@@ -1,0 +1,38 @@
+// FastNoiseSIMD_neon.cpp
+//
+// MIT License
+//
+// Copyright(c) 2017 Jordan Peck
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// The developer's email is jorzixdan.me2@gzixmail.com (for great email, take
+// off every 'zix'.)
+//
+
+#include "FastNoiseSIMD.h"
+#ifdef FN_COMPILE_NEON
+
+#define SIMD_LEVEL_H FN_NEON
+#include "FastNoiseSIMD_internal.h"
+#include <arm_neon.h>
+
+#define SIMD_LEVEL FN_NEON
+#include "FastNoiseSIMD_internal.cpp"
+#endif

--- a/animation_nodes/libs/FastNoiseSIMD/source/compile_macos.sh
+++ b/animation_nodes/libs/FastNoiseSIMD/source/compile_macos.sh
@@ -1,8 +1,17 @@
+#!/bin/sh
+set -e
+
 gcc -c FastNoiseSIMD.cpp -std=c++11 -fPIC -O3
 gcc -c FastNoiseSIMD_internal.cpp -std=c++11 -fPIC -O3
-gcc -c FastNoiseSIMD_sse2.cpp -std=c++11 -fPIC -O3 -msse2
-gcc -c FastNoiseSIMD_sse41.cpp -std=c++11 -fPIC -O3 -msse4.1
-gcc -c FastNoiseSIMD_avx2.cpp -std=c++11 -fPIC -O3 -march=core-avx2
+
+if [ "$(arch)" == "arm64" ]; then
+	gcc -c FastNoiseSIMD_neon.cpp -std=c++11 -fPIC -O3
+else
+	gcc -c FastNoiseSIMD_sse2.cpp -std=c++11 -fPIC -O3 -msse2
+	gcc -c FastNoiseSIMD_sse41.cpp -std=c++11 -fPIC -O3 -msse4.1
+	gcc -c FastNoiseSIMD_avx2.cpp -std=c++11 -fPIC -O3 -march=core-avx2
+fi
+
 ar rcs libFastNoiseSIMD_macos.a *.o
 
 echo "Done."


### PR DESCRIPTION
This is all that's needed to make it build and run on arm64 macOS.