### PR TITLE
Add Scene Changed auto execution option and make it the default

### DIFF
--- a/animation_nodes/base_types/node_tree.py
+++ b/animation_nodes/base_types/node_tree.py
@@ -63,7 +63,9 @@ class AnimationNodeTree(bpy.types.NodeTree):
         if not a.enabled: return False
         if not self.hasMainExecutionUnits: return False
 
-        if "Frame" in events and (a.sceneUpdate or a.frameChanged): return True
+        if "Scene" in events and (a.always or a.sceneChanged): return True
+
+        if "Frame" in events and (a.always or a.sceneChanged or a.frameChanged): return True
 
         if not (isRendering() or isInterfaceLocked()):
             if self.timeSinceLastAutoExecution < a.minTimeDifference: return False
@@ -71,10 +73,10 @@ class AnimationNodeTree(bpy.types.NodeTree):
             if "Property" in events and a.propertyChanged: return True
             if "Tree" in events and a.treeChanged: return True
             if events.intersection({"File", "Addon"}) and any(
-                (a.sceneUpdate, a.frameChanged, a.propertyChanged, a.treeChanged)): return True
+                (a.always, a.sceneChanged, a.frameChanged, a.propertyChanged, a.treeChanged)): return True
 
             if not isViewportRendering() or isAnimationPlaying():
-                if a.sceneUpdate: return True
+                if a.always: return True
 
         return customTriggerHasBeenActivated
 

--- a/animation_nodes/base_types/tree_auto_execution.py
+++ b/animation_nodes/base_types/tree_auto_execution.py
@@ -130,16 +130,19 @@ class AutoExecutionProperties(bpy.types.PropertyGroup):
     enabled: BoolProperty(default = True, name = "Enabled",
         description = "Enable auto execution for this node tree")
 
-    sceneUpdate: BoolProperty(default = True, name = "Scene Update",
+    always: BoolProperty(default = False, name = "Always",
         description = "Execute many times per second to react on all changes in real time (deactivated during preview rendering)")
 
-    frameChanged: BoolProperty(default = False, name = "Frame Changed",
+    sceneChanged: BoolProperty(default = True, name = "Scene Changed",
+        description = "Execute after anything in the scene changed")
+
+    frameChanged: BoolProperty(default = True, name = "Frame Changed",
         description = "Execute after the frame changed")
 
-    propertyChanged: BoolProperty(default = False, name = "Property Changed",
+    propertyChanged: BoolProperty(default = True, name = "Property Changed",
         description = "Execute when a attribute in a animation node tree changed")
 
-    treeChanged: BoolProperty(default = False, name = "Tree Changed",
+    treeChanged: BoolProperty(default = True, name = "Tree Changed",
         description = "Execute when the node tree changes (create/remove links and nodes)")
 
     minTimeDifference: FloatProperty(name = "Min Time Difference",

--- a/animation_nodes/events.py
+++ b/animation_nodes/events.py
@@ -39,6 +39,13 @@ def frameChanged(scene, depsgraph):
     event_handler.update(event.getActives().union({"Frame"}))
     evaluatedDepsgraph = None
 
+@eventHandler("DEPSGRAPH_UPDATE_POST")
+def sceneChanged(scene, depsgraph):
+    global evaluatedDepsgraph
+    evaluatedDepsgraph = depsgraph
+    event_handler.update(event.getActives().union({"Scene"}))
+    evaluatedDepsgraph = None
+
 def propertyChanged(self = None, context = None):
     event.propertyChanged = True
     resetMeasurements()

--- a/animation_nodes/ui/auto_execution_panel.py
+++ b/animation_nodes/ui/auto_execution_panel.py
@@ -37,10 +37,13 @@ class AutoExecutionPanel(bpy.types.Panel):
         col = layout.column()
         col.active = not isRendering
         text = "Always" if not isRendering else "Always (deactivated)"
-        col.prop(autoExecution, "sceneUpdate", text = text)
+        col.prop(autoExecution, "always", text = text)
 
         col = layout.column()
-        col.active = not autoExecution.sceneUpdate or isRendering
+        col.active = not autoExecution.always or isRendering
+        col.prop(autoExecution, "sceneChanged", text = "Scene Changed")
+        col = col.column()
+        col.active = not autoExecution.sceneChanged
         col.prop(autoExecution, "treeChanged", text = "Tree Changed")
         col.prop(autoExecution, "frameChanged", text = "Frame Changed")
         col.prop(autoExecution, "propertyChanged", text = "Property Changed")

--- a/animation_nodes/utils/handlers.py
+++ b/animation_nodes/utils/handlers.py
@@ -17,6 +17,7 @@ fileSavePreHandlers = []
 fileLoadPostHandlers = []
 addonLoadPostHandlers = []
 frameChangePostHandlers = []
+depsgraphUpdatePostHandlers = []
 
 renderPreHandlers = []
 renderInitHandlers = []
@@ -30,6 +31,7 @@ def eventHandler(event):
         if event == "FILE_LOAD_POST": fileLoadPostHandlers.append(function)
         if event == "ADDON_LOAD_POST": addonLoadPostHandlers.append(function)
         if event == "FRAME_CHANGE_POST": frameChangePostHandlers.append(function)
+        if event == "DEPSGRAPH_UPDATE_POST": depsgraphUpdatePostHandlers.append(function)
 
         if event == "RENDER_INIT": renderInitHandlers.append(function)
         if event == "RENDER_PRE": renderPreHandlers.append(function)
@@ -71,6 +73,11 @@ def frameChangedPost(scene, depsgraph):
         handler(scene, depsgraph)
 
 @persistent
+def depsgraphUpdatePost(scene, depsgraph):
+    for handler in depsgraphUpdatePostHandlers:
+        handler(scene, depsgraph)
+
+@persistent
 def renderInitialized(scene):
     for handler in renderInitHandlers:
         handler()
@@ -87,6 +94,7 @@ def renderCompleted(scene):
 
 def register():
     bpy.app.handlers.frame_change_post.append(frameChangedPost)
+    bpy.app.handlers.depsgraph_update_post.append(frameChangedPost)
     bpy.app.timers.register(always, persistent = True)
     bpy.app.handlers.load_post.append(loadPost)
     bpy.app.handlers.save_pre.append(savePre)
@@ -101,6 +109,7 @@ def register():
 
 def unregister():
     bpy.app.handlers.frame_change_post.remove(frameChangedPost)
+    bpy.app.handlers.depsgraph_update_post.remove(frameChangedPost)
     bpy.app.handlers.load_post.remove(loadPost)
     bpy.app.handlers.save_pre.remove(savePre)
     bpy.app.timers.unregister(always)


### PR DESCRIPTION
This patch adds another auto execution option *Scene Changed*. This option executes the node tree when and if and only if anything changes in the scene. Additionally, the option is now enabled by default and the *Always* option is now disabled by default.

Having *Always* default to True was always questionable as it is very inefficient and mostly superfluous. However, the concern was that *Always* is the most expected execution behavior of Animation Nodes for users, especially for novices, because all changes are immediately reflected to the scene without worrying about the ideal execution behavior.

The *Scene Changed* option is, I believe, the best compromise we can get. Because it only executes when something actually changes in the scene, and at the same time, it is inclusive to all events that the user would expect to trigger an execution.

![20210801-120212](https://user-images.githubusercontent.com/25300994/127766985-0cc492a9-8f98-43d1-904b-249ac9526d33.png)

---

I would like to refactor other execution behaviors to supplement this change, but we shall look at those refactors separately later.