### PR TITLE
Optimize execution units setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Fixed *Mesh Object Input* node custom attribute reading with enabled modifiers.
+- Fixed failing dialogs after recent API change.
 
 ### Changed
 

--- a/animation_nodes/base_types/node_tree.py
+++ b/animation_nodes/base_types/node_tree.py
@@ -85,9 +85,9 @@ class AnimationNodeTree(bpy.types.NodeTree):
         self.autoExecution.lastExecutionTimestamp = time.process_time()
 
     def execute(self):
-        setupExecutionUnits()
+        setupExecutionUnits([self])
         self._execute()
-        finishExecutionUnits()
+        finishExecutionUnits([self])
 
     def _execute(self):
         units = self.mainUnits

--- a/animation_nodes/event_handler.py
+++ b/animation_nodes/event_handler.py
@@ -16,13 +16,15 @@ def update(events):
     if didNameChange() or events.intersection({"File", "Addon", "Tree"}):
         updateEverything()
 
-    if problems.canAutoExecute():
-        nodeTrees = list(iterAutoExecutionNodeTrees(events))
-        if len(nodeTrees) > 0:
-            setupExecutionUnits()
-            executeNodeTrees(nodeTrees)
-            afterExecution()
-            finishExecutionUnits()
+    if not problems.canAutoExecute(): return
+
+    nodeTrees = list(iterAutoExecutionNodeTrees(events))
+    if len(nodeTrees) == 0: return
+
+    setupExecutionUnits(nodeTrees)
+    executeNodeTrees(nodeTrees)
+    afterExecution()
+    finishExecutionUnits(nodeTrees)
 
 
 def failsToWriteToIDClasses():

--- a/animation_nodes/execution/units.py
+++ b/animation_nodes/execution/units.py
@@ -2,14 +2,15 @@ import traceback
 from .. import problems
 from collections import defaultdict
 from . cache import clearExecutionCache
+from .. utils.timing import measureTime
 from . measurements import resetMeasurements
 from . main_execution_unit import MainExecutionUnit
 from . loop_execution_unit import LoopExecutionUnit
 from . group_execution_unit import GroupExecutionUnit
 from . script_execution_unit import ScriptExecutionUnit
-from .. tree_info import getNetworksByType, getSubprogramNetworks
 from .. utils.nodes import getAnimationNodeTrees, iterAnimationNodes
 from .. problems import ExceptionDuringCodeCreation, CouldNotSetupExecutionUnits
+from .. tree_info import getNetworksByType, getSubprogramNetworks, getNetworkByIdentifier
 
 _mainUnitsByNodeTree = defaultdict(list)
 _subprogramUnitsByIdentifier = {}
@@ -49,27 +50,30 @@ def createSubprogramUnits(nodeByID):
         _subprogramUnitsByIdentifier[network.identifier] = unit
 
 
-def setupExecutionUnits():
+@measureTime
+def setupExecutionUnits(nodeTrees):
     try:
-        if len(getAnimationNodeTrees()) == 0: return
+        if len(nodeTrees) == 0: return
         if not problems.canExecute(): return
 
-        for unit in getExecutionUnits():
+        executionUnits = getExecutionUnits(nodeTrees)
+
+        for unit in executionUnits:
             unit.setup()
 
         subprograms = {}
         for identifier, unit in _subprogramUnitsByIdentifier.items():
             subprograms["_subprogram" + identifier] = unit.execute
 
-        for unit in getExecutionUnits():
+        for unit in executionUnits:
             unit.insertSubprogramFunctions(subprograms)
     except:
         print("\n"*5)
         traceback.print_exc()
         CouldNotSetupExecutionUnits().report()
 
-def finishExecutionUnits():
-    for unit in getExecutionUnits():
+def finishExecutionUnits(nodeTrees):
+    for unit in getExecutionUnits(nodeTrees):
         unit.finish()
 
     clearExecutionCache()
@@ -89,13 +93,22 @@ def getSubprogramUnitsByName(name):
     return programs
 
 def getExecutionUnitByNetwork(network):
-    for unit in getExecutionUnits():
+    for unit in getExecutionUnits([network.nodeTree]):
         if unit.network == network: return unit
 
-def getExecutionUnits():
+def getExecutionUnits(nodeTrees):
     units = []
-    for mainUnits in _mainUnitsByNodeTree.values():
-        units.extend(mainUnits)
-    for subprogramUnit in _subprogramUnitsByIdentifier.values():
-        units.append(subprogramUnit)
+    for nodeTree in nodeTrees:
+        units.extend(_mainUnitsByNodeTree[nodeTree.name])
+
+        for network in nodeTree.networks:
+            for subprogramID in getNeededSubprogramIDs(network):
+                units.append(_subprogramUnitsByIdentifier[subprogramID])
     return units
+
+def getNeededSubprogramIDs(network):
+    subprogramIDs = network.referencedSubprogramIDs.copy()
+    for subprogramID in network.referencedSubprogramIDs:
+        subNetwork = getNetworkByIdentifier(subprogramID)
+        subprogramIDs.update(getNeededSubprogramIDs(subNetwork))
+    return subprogramIDs

--- a/animation_nodes/id_keys/data_types/integer_type.py
+++ b/animation_nodes/id_keys/data_types/integer_type.py
@@ -69,7 +69,7 @@ class IDKeysFromSortedObjects(bpy.types.Operator):
         items = locationModeItems)
 
     def invoke(self, context, event):
-        return context.window_manager.invoke_props_dialog(self, width = 250 * getDpiFactor())
+        return context.window_manager.invoke_props_dialog(self, width = int(250 * getDpiFactor()))
 
     def draw(self, context):
         layout = self.layout

--- a/animation_nodes/id_keys/new_id_key.py
+++ b/animation_nodes/id_keys/new_id_key.py
@@ -23,7 +23,7 @@ class NewIDKey(bpy.types.Operator):
     keyDataType: EnumProperty(name = "Key Data Type", items = keyDataTypeItems)
 
     def invoke(self, context, event):
-        return context.window_manager.invoke_props_dialog(self, width = 250 * getDpiFactor())
+        return context.window_manager.invoke_props_dialog(self, width = int(250 * getDpiFactor()))
 
     def draw(self, context):
         layout = self.layout

--- a/animation_nodes/nodes/subprogram/invoke_subprogram.py
+++ b/animation_nodes/nodes/subprogram/invoke_subprogram.py
@@ -196,7 +196,7 @@ class ChangeSubprogram(bpy.types.Operator):
             node = getNodeByIdentifier(self.nodeIdentifier)
             self.subprogram = node.subprogramIdentifier
         except: pass # when the old subprogram identifier doesn't exist
-        return context.window_manager.invoke_props_dialog(self, width = 400 * getDpiFactor())
+        return context.window_manager.invoke_props_dialog(self, width = int(400 * getDpiFactor()))
 
     def check(self, context):
         return True

--- a/animation_nodes/operators/rename_datablock.py
+++ b/animation_nodes/operators/rename_datablock.py
@@ -14,7 +14,7 @@ class RenameDatablockPopupOperator(bpy.types.Operator):
 
     def invoke(self, context, event):
         self.newName = self.oldName
-        return context.window_manager.invoke_props_dialog(self, width = 200 * getDpiFactor())
+        return context.window_manager.invoke_props_dialog(self, width = int(200 * getDpiFactor()))
 
     def check(self, context):
         return True

--- a/animation_nodes/ui/node_popup.py
+++ b/animation_nodes/ui/node_popup.py
@@ -14,7 +14,7 @@ class NodePopup(bpy.types.Operator):
     executeFunctionName: StringProperty(default = "")
 
     def invoke(self, context, event):
-        return context.window_manager.invoke_props_dialog(self, width = self.width * getDpiFactor())
+        return context.window_manager.invoke_props_dialog(self, width = int(self.width * getDpiFactor()))
 
     def draw(self, context):
         try: node = getNodeByIdentifier(self.nodeIdentifier)

--- a/animation_nodes/ui/node_settings_floating.py
+++ b/animation_nodes/ui/node_settings_floating.py
@@ -27,7 +27,7 @@ class FloatingNodeSettingsPanel(bpy.types.Operator):
 
     def invoke(self, context, event):
         self.nodeIdentifier = context.active_node.identifier
-        return context.window_manager.invoke_props_dialog(self, width = 250 * getDpiFactor())
+        return context.window_manager.invoke_props_dialog(self, width = int(250 * getDpiFactor()))
 
     def draw(self, context):
         try:


### PR DESCRIPTION
Currently, all execution units are setup even if non of them are used by
the main execution units currently executing. This is highly inefficient
for setups where passive node trees are used as template libraries. This
patch optimize this by only setting up units that are references by the
main units currently executing. This yields a 50x speedup in the sample
shared in #1783.

Tree changes still suffer greatly from the same symptoms, but this shall be looked at later.

Resolves #1783.