### PR TITLE
Fix custom property assignment types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed *Insert Vertex Group* node.
 - Fixed *Convert* node when converting to Action.
 - Fixed *Object Action Output* node for Actions with named attributes.
+- Fixed *Object Action Output* nodes overwriting Custom Property types.
 
 ### Changed
 

--- a/animation_nodes/utils/attributes.py
+++ b/animation_nodes/utils/attributes.py
@@ -35,6 +35,8 @@ def getAttributeSetterLines(objectName, propName, valueName):
     yield f"try: {propPath} = type({propPath})({valueName})"
     # Property does not exist; default to new float
     yield f"except: {propPath} = {valueName}"
+    # Force dependency graph update. See https://developer.blender.org/T63793#881438
+    yield f"{objectName}.update_tag()"
 
 def getPropertyPath(objectName, propName):
     if propName.startswith("["):

--- a/animation_nodes/utils/attributes.py
+++ b/animation_nodes/utils/attributes.py
@@ -23,7 +23,7 @@ def getMultiAttibuteSetter(propNames):
     code = "def setter(owner, values):\n"
     for i, prop in enumerate(propNames):
         lines = getAttributeSetterLines("owner", prop, "values[{}]".format(i))
-        code += "".join("    " + line + "\n" for line in lines)
+        code += "".join(f"    {line}\n" for line in lines)
     code += "    pass"
     variables = {}
     exec(code, variables)

--- a/animation_nodes/utils/attributes.py
+++ b/animation_nodes/utils/attributes.py
@@ -48,16 +48,14 @@ def pathBelongsToArray(object, dataPath):
     return pathArrayCache.get(inputHash, None)
 
 def _pathBelongsToArray(object, dataPath):
-    if "." in dataPath:
-        pathToProperty, propertyName = dataPath.rsplit(".", 1)
-        pathToProperty = "." + pathToProperty
-    else:
-        pathToProperty = ""
-        propertyName = dataPath
+    if not dataPath.startswith("[") and not dataPath.startswith("."):
+        dataPath = "." + dataPath
 
     try:
-        amount = eval("object{}.bl_rna.properties[{}].array_length".format(pathToProperty, repr(propertyName)))
-        return amount > 0
+        data = eval("object{}".format(dataPath))
+        if isinstance(data, str):
+            return False # Strings have len() but aren't arrays
+        return len(data) > 0
     except:
         # Path not found
         return None

--- a/animation_nodes/utils/attributes.py
+++ b/animation_nodes/utils/attributes.py
@@ -8,13 +8,15 @@ def getattrRecursive(owner, propName):
 
 @functools.lru_cache(maxsize = 1024)
 def getAttributeSetter(propName):
+    propPath = getPropertyPath("owner", propName)
     variables = {}
-    exec("def attrSetter(owner, value): owner.{} = value".format(propName), variables)
+    exec(f"def attrSetter(owner, value): {propPath} = value", variables)
     return variables["attrSetter"]
 
 @functools.lru_cache(maxsize = 1024)
 def getAttributeGetter(propName):
-    return eval("lambda owner: owner.{}".format(propName))
+    propPath = getPropertyPath("owner", propName)
+    return eval(f"lambda owner: {propPath}")
 
 @functools.lru_cache(maxsize = 1024)
 def getMultiAttibuteSetter(propNames):
@@ -34,6 +36,12 @@ def getAttributeSetterLines(objectName, propName, valueName):
     # Property does not exist; default to new float
     yield f"except: {propPath} = {valueName}"
 
+def getPropertyPath(objectName, propName):
+    if propName.startswith("["):
+        # Property is a named attribute
+        return f"{objectName}{propName}"
+    else:
+        return f"{objectName}.{propName}"
 
 def hasEvaluableRepr(value):
     try: return eval(repr(value)) == value


### PR DESCRIPTION
Modifies the `Object Action Output` node's attribute setter function to perform a type cast.

## Notes
* `object.bl_rna.properties` does not contain Custom Properties, but copies of items in `bl_rna.properties` seem to exist directly on the `object` (such as `object.bl_rna.properties[location]` and `object.location`).
* Unlike `bl_rna.properties`, properties accessed directly from the `object` do not have an `array_length` attribute, so `len()` was used instead.

Resolves #1815