### PR TITLE
OpenBSD support

### DIFF
--- a/_setuputils/compilation.py
+++ b/_setuputils/compilation.py
@@ -121,6 +121,6 @@ def getSetupOptions(path):
 def getExtensionArgsFromSetupOptions(options):
     args = {}
     if "c++11" in options:
-        if onLinux or onMacOS:
+        if onLinux or onMacOS or onOpenBSD:
             args["extra_compile_args"] = ["-std=c++11"]
     return args

--- a/_setuputils/generic.py
+++ b/_setuputils/generic.py
@@ -12,8 +12,9 @@ _globals = set(globals().keys())
 onLinux = sys.platform.startswith("linux")
 onWindows = sys.platform.startswith("win")
 onMacOS = sys.platform == "darwin"
+onOpenBSD = sys.platform.startswith("openbsd")
 
-if not (onLinux or onWindows or onMacOS):
+if not (onLinux or onWindows or onMacOS or onOpenBSD):
     raise Exception("unknown OS")
 
 def getPlatformSummary():

--- a/animation_nodes/libs/FastNoiseSIMD/source/compile_openbsd.sh
+++ b/animation_nodes/libs/FastNoiseSIMD/source/compile_openbsd.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# copied from file compile_macos.sh
+# on OpenBSD `pkg_info -L gcc` - gcc installs as /usr/local/bin/egcc
+
+set -e
+
+egcc -c FastNoiseSIMD.cpp -std=c++11 -fPIC -O3
+egcc -c FastNoiseSIMD_internal.cpp -std=c++11 -fPIC -O3
+
+if [ "$(arch)" == "arm64" ]; then
+	egcc -c FastNoiseSIMD_neon.cpp -std=c++11 -fPIC -O3
+else
+	egcc -c FastNoiseSIMD_sse2.cpp -std=c++11 -fPIC -O3 -msse2
+	egcc -c FastNoiseSIMD_sse41.cpp -std=c++11 -fPIC -O3 -msse4.1
+	egcc -c FastNoiseSIMD_avx2.cpp -std=c++11 -fPIC -O3 -march=core-avx2
+fi
+
+egcc-ar rcs libFastNoiseSIMD_openbsd.a *.o
+
+echo "Done."

--- a/animation_nodes/libs/FastNoiseSIMD/wrapper_setup_info.py
+++ b/animation_nodes/libs/FastNoiseSIMD/wrapper_setup_info.py
@@ -38,4 +38,8 @@ def getCompileInfo(utils):
         return ("libFastNoiseSIMD_macos.a",
                 ["sh", os.path.join(sourceDir, "compile_macos.sh")],
                 {"libraries" : ["FastNoiseSIMD_macos"]})
+    if utils.onOpenBSD:
+        return ("libFastNoiseSIMD_openbsd.a",
+                ["sh", os.path.join(sourceDir, "compile_openbsd.sh")],
+                {"libraries" : ["FastNoiseSIMD_openbsd"]})
     raise Exception("unknown platform")

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ initPath = os.path.join(currentDirectory, addonName, "__init__.py")
 if onLinux: currentOS = "linux"
 elif onWindows: currentOS = "windows"
 elif onMacOS: currentOS = "macOS"
+elif onOpenBSD: currentOS = "openbsd"
 addonVersion = getAddonVersion(initPath)
 exportName = "{}_v{}_{}_{}_py{}{}".format(
     addonName, *addonVersion[:2], currentOS, *sys.version_info[:2])


### PR DESCRIPTION
`python3 setup.py build` errors:
```
Run Cythonize
...
123/123:
Compiling /tmp/animation_nodes-OpenBSD-support/animation_nodes/utils/pointers.pyx because it changed.
[1/1] Cythonizing /tmp/animation_nodes-OpenBSD-support/animation_nodes/utils/pointers.pyx
egcc: fatal error: cannot execute 'cc1plus': execvp: No such file or directory
compilation terminated.
```
```
Compile FastNoiseSIMD
...
63/123:
running build_ext
building 'animation_nodes.libs.FastNoiseSIMD.wrapper' extension
creating build/temp.openbsd-7.1-amd64-3.9/tmp/animation_nodes-OpenBSD-support/animation_nodes/libs
creating build/temp.openbsd-7.1-amd64-3.9/tmp/animation_nodes-OpenBSD-support/animation_nodes/libs/FastNoiseSIMD
cc -pthread -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -pipe -g -fPIC -O2 -pipe -g -O2 -pipe -g -fPIC -I/tmp/animation_nodes-OpenBSD-support/animation_nodes/libs/FastNoiseSIMD/source -I/usr/local/include/python3.9 -c /tmp/animation_nodes-OpenBSD-support/animation_nodes/libs/FastNoiseSIMD/wrapper.cpp -o build/temp.openbsd-7.1-amd64-3.9/tmp/animation_nodes-OpenBSD-support/animation_nodes/libs/FastNoiseSIMD/wrapper.o -g0 -std=c++11
c++ -pthread -shared -fPIC -L/usr/local/lib/ build/temp.openbsd-7.1-amd64-3.9/tmp/animation_nodes-OpenBSD-support/animation_nodes/libs/FastNoiseSIMD/wrapper.o -L/tmp/animation_nodes-OpenBSD-support/animation_nodes/libs/FastNoiseSIMD/source -L/usr/local/lib -lFastNoiseSIMD_openbsd -o /tmp/animation_nodes-OpenBSD-support/animation_nodes/libs/FastNoiseSIMD/wrapper.cpython-39.so
ld: error: unable to find library -lFastNoiseSIMD_openbsd
c++: error: linker command failed with exit code 1 (use -v to see invocation)
error: command '/usr/bin/c++' failed with exit code 1
```

---

`cc1plus` is absent on my OpenBSD machine, even with `find / -name cc1plus`

OpenBSD itself doesn't use `gcc` relying on `clang` instead. It might be more appropriate to compile AN with `clang` for OpenBSD. `gcc` and `clang` arguments are incompatible, though.

resolve #1878