### PR TITLE
Fix: Symbol not found: ___chkstk_darwin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fixed *BMesh Mesh Data* not loading indices.
 - Fixed *Set Bevel Vertex Weight* and *Set Bevel Edge Weight* nodes for API changes.
 - Fixed *Set Keyframe* node failing when path contains a subscript.
+- Fixed symbol not found error on MacOS 10.
 
 ### Changed
 

--- a/_setuputils/compilation.py
+++ b/_setuputils/compilation.py
@@ -76,6 +76,9 @@ def getExtensionFromPath(path, addonDirectory, includeDirs = []):
         "depends" : []
     }
 
+    if onMacOS:
+        kwargs["extra_compile_args"].append("-fno-stack-check")
+
     for key, values in getExtensionArgsFromSetupOptions(getSetupOptions(path)).items():
         kwargs[key].extend(values)
 

--- a/_setuputils/compilation.py
+++ b/_setuputils/compilation.py
@@ -76,6 +76,7 @@ def getExtensionFromPath(path, addonDirectory, includeDirs = []):
         "depends" : []
     }
 
+    # Disable stack checking because it causes link errors for MacOS 10.
     if onMacOS:
         kwargs["extra_compile_args"].append("-fno-stack-check")
 


### PR DESCRIPTION
Disable stack checking on MacOS to resolve this error.