### PR TITLE
Change data path type check in attributes.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Added support for non-list types in *Object Data Path Output* node.
+
 ### Fixed
 
 - Fixed Sequence sockets for recent API change.

--- a/animation_nodes/utils/attributes.py
+++ b/animation_nodes/utils/attributes.py
@@ -65,7 +65,7 @@ def _pathBelongsToArray(object, dataPath):
     try:
         data = eval(f"object{dataPath}")
         if any(isinstance(data, ty) for ty in [str, float, int, bool]):
-            # Strings have len() but aren't arrays
+            # Strings and scalars shuldn't be indexed
             return False
         return len(data) > 0
     except:

--- a/animation_nodes/utils/attributes.py
+++ b/animation_nodes/utils/attributes.py
@@ -64,7 +64,7 @@ def _pathBelongsToArray(object, dataPath):
 
     try:
         data = eval(f"object{dataPath}")
-        if isinstance(data, str):
+        if any(isinstance(data, ty) for ty in [str, float, int, bool]):
             # Strings have len() but aren't arrays
             return False
         return len(data) > 0

--- a/animation_nodes/utils/attributes.py
+++ b/animation_nodes/utils/attributes.py
@@ -64,7 +64,7 @@ def _pathBelongsToArray(object, dataPath):
 
     try:
         data = eval(f"object{dataPath}")
-        if any(isinstance(data, ty) for ty in [str, float, int, bool]):
+        if isinstance(data, (str, float, int, bool)):
             # Strings and scalars shuldn't be indexed
             return False
         return len(data) > 0


### PR DESCRIPTION
Object Data Path Output can't set scalar data due to wrong `pathBelongsToArray` type check.

It uses `pathBelongsToArray` to determine whether to use the index.
However, `_pathBelongsToArray` returns None if `len()` called with types such as float and int.
Since `createSetFunction` returns None when `pathBelongsToArray` returns None, it seems that it can't set Data Paths such as floats.

This PR fixes the problem by explicitly returning False for str, float, int, and bool cases.